### PR TITLE
added new AttachmentTypes

### DIFF
--- a/proto/Events/DiadocMessage-GetApi.proto
+++ b/proto/Events/DiadocMessage-GetApi.proto
@@ -142,5 +142,7 @@ enum AttachmentType {
 	RoamingNotification = 39;
 	SupplementaryAgreement = 40;
 	CustomData = 64;
+	MoveDocument = 65;
+	ResolutionChainAssignmentAttachment = 66;
 	//Неизвестные типы должны обрабатываться как Nonformalized
 }

--- a/src/Com/AttachmentType.cs
+++ b/src/Com/AttachmentType.cs
@@ -45,6 +45,8 @@ namespace Diadoc.Api.Com
 		ServiceDetails = 38,
 		RoamingNotification = 39,
 		SupplementaryAgreement = 40,
-		CustomData = 64
+		CustomData = 64,
+		MoveDocument = 65,
+		ResolutionChainAssignmentAttachment = 66
 	}
 }

--- a/src/Proto/Events/DiadocMessage-GetApi.proto.cs
+++ b/src/Proto/Events/DiadocMessage-GetApi.proto.cs
@@ -745,7 +745,13 @@ namespace Diadoc.Api.Proto.Events
       SupplementaryAgreement = 40,
             
       [global::ProtoBuf.ProtoEnum(Name=@"CustomData", Value=64)]
-      CustomData = 64
+      CustomData = 64,
+            
+      [global::ProtoBuf.ProtoEnum(Name=@"MoveDocument", Value=65)]
+      MoveDocument = 65,
+            
+      [global::ProtoBuf.ProtoEnum(Name=@"ResolutionChainAssignmentAttachment", Value=66)]
+      ResolutionChainAssignmentAttachment = 66
     }
   
 }


### PR DESCRIPTION
Не надо мержить до релиза "ветки в цепочках согласования"

Добавил новый AttachmentType в enum - ResolutionChainAssignment, оказалось, что не хватало еще одного (очень старого) - MoveDocument, добавил его тоже