### PR TITLE
ITemplateToPost.LockMode property added for COM-Wrapper

### DIFF
--- a/src/Proto/Events/DiadocMessage.cs
+++ b/src/Proto/Events/DiadocMessage.cs
@@ -469,6 +469,7 @@ namespace Diadoc.Api.Proto.Events
 		string ToBoxId { get; set; }
 		string MessageFromBoxId { get; set; }
 		string MessageToBoxId { get; set; }
+		LockMode LockMode { get; set; } 
 
 		string MessageToDepartmentId { get; set; }
 


### PR DESCRIPTION
Добавил проброс свойства LockMode в COM-обертку (объединил коммиты https://github.com/diadoc/diadocsdk-csharp/pull/419)