### PR TITLE
Rename overloaded method GetMessage in ComDiadocApi

### DIFF
--- a/src/ComDiadocApi.cs
+++ b/src/ComDiadocApi.cs
@@ -182,9 +182,10 @@ namespace Diadoc.Api
 		PrintFormResult GeneratePrintForm(string authToken, string boxId, string messageId, string documentId);
 
 		[Obsolete("Use GetGeneratedPrintForm without `documentType` parameter")]
-		PrintFormResult GetGeneratedPrintForm(string authToken, int documentType, string printFormId);
+		PrintFormResult GetGeneratedPrintFormOld(string authToken, int documentType, string printFormId);
 
 		PrintFormResult GetGeneratedPrintForm(string authToken, string printFormId);
+
 		string GeneratePrintFormFromAttachment(string authToken, int documentType, byte[] content);
 		DateTime NullDateTime();
 		DocumentList GetDocuments(string authToken, [MarshalAs(UnmanagedType.IDispatch)] object filter);
@@ -939,7 +940,7 @@ namespace Diadoc.Api
 		}
 
 		[Obsolete("Use GetGeneratedPrintForm without `documentType` parameter")]
-		public PrintFormResult GetGeneratedPrintForm(string authToken, int documentType, string printFormId)
+		public PrintFormResult GetGeneratedPrintFormOld(string authToken, int documentType, string printFormId)
 		{
 			return diadoc.GetGeneratedPrintForm(authToken, (DocumentType) documentType, printFormId);
 		}

--- a/src/ComDiadocApi.cs
+++ b/src/ComDiadocApi.cs
@@ -168,7 +168,7 @@ namespace Diadoc.Api
 			string entityId);
 
 		Message GetMessage(string authToken, string boxId, string messageId, bool withOriginalSignature = false, bool injectEntityContent = false);
-		Message GetMessage(string authToken, string boxId, string messageId, string entityId, bool withOriginalSignature = false, bool injectEntityContent = false);
+		Message GetMessageForDocument(string authToken, string boxId, string messageId, string entityId, bool withOriginalSignature = false, bool injectEntityContent = false);
 		Template GetTemplate(string authToken, string boxId, string messageId);
 		void RecycleDraft(string authToken, string boxId, string draftId);
 		Message SendDraft(string authToken, [MarshalAs(UnmanagedType.IDispatch)] object draftToSend);
@@ -878,9 +878,9 @@ namespace Diadoc.Api
 			return diadoc.GetMessage(authToken, boxId, messageId, withOriginalSignature, injectEntityContent);
 		}
 
-		public Message GetMessage(string authToken, string boxId, string messageId, string entityId, bool withOriginalSignature = false, bool injectEntityContent = false)
+		public Message GetMessageForDocument(string authToken, string boxId, string messageId, string documentId, bool withOriginalSignature = false, bool injectEntityContent = false)
 		{
-			return diadoc.GetMessage(authToken, boxId, messageId, entityId, withOriginalSignature, injectEntityContent);
+			return diadoc.GetMessage(authToken, boxId, messageId, documentId, withOriginalSignature, injectEntityContent);
 		}
 
 		public Template GetTemplate(string authToken, string boxId, string messageId)

--- a/src/IDiadocApi.cs
+++ b/src/IDiadocApi.cs
@@ -95,7 +95,7 @@ namespace Diadoc.Api
 		GeneratedFile GenerateSenderTitleXml(string authToken, string boxId, string documentTypeNamedId, string documentFunction, string documentVersion, byte[] userContractData, bool disableValidation = false, string editingSettingId = null);
 		GeneratedFile GenerateRecipientTitleXml(string authToken, string boxId, string senderTitleMessageId, string senderTitleAttachmentId, byte[] userContractData, string documentVersion = null);
 		Message GetMessage(string authToken, string boxId, string messageId, bool withOriginalSignature = false, bool injectEntityContent = false);
-		Message GetMessage(string authToken, string boxId, string messageId, string entityId, bool withOriginalSignature = false, bool injectEntityContent = false);
+		Message GetMessage(string authToken, string boxId, string messageId, string documentId, bool withOriginalSignature = false, bool injectEntityContent = false);
 		Template GetTemplate(string authToken, string boxId, string templateId, string entityId = null);
 		void RecycleDraft(string authToken, string boxId, string draftId);
 		Message SendDraft(string authToken, DraftToSend draftToSend, string operationId = null);


### PR DESCRIPTION
Overloaded method `GetMessage` accepting parameter `documentId` is now called `GetMessageForDocument`

See https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1402-avoid-overloads-in-com-visible-interfaces?view=vs-2017