### PR TITLE
Fixing #496

### DIFF
--- a/src/DiadocApi.Async.cs
+++ b/src/DiadocApi.Async.cs
@@ -763,7 +763,7 @@ namespace Diadoc.Api
 				boxId,
 				documentTypeNamedId,
 				documentFunction,
-				documentFunction,
+				documentVersion,
 				titleIndex,
 				content);
 		}


### PR DESCRIPTION
В методе была опечатка documentFuncion передавался дважды