### PR TITLE
WIP: Заменять все пустые строки на null для контрактов, используемых в GenerateSenderTitleXml

### DIFF
--- a/tests/DiadocApi-Tests-net35.csproj
+++ b/tests/DiadocApi-Tests-net35.csproj
@@ -61,6 +61,7 @@
   <ItemGroup>
     <Compile Include="ComClasses_Test.cs" />
     <Compile Include="ComEnumsAreCompatibleWithProtoEnums_Test.cs" />
+    <Compile Include="NullifyEmptyStringProperties_Test.cs" />
     <Compile Include="ComInterfaceAttributes_Test.cs" />
     <Compile Include="XmlSerialization_Test.cs" />
   </ItemGroup>

--- a/tests/DiadocApi-Tests-net45.csproj
+++ b/tests/DiadocApi-Tests-net45.csproj
@@ -62,6 +62,7 @@
     <Compile Include="ComClasses_Test.cs" />
     <Compile Include="ComEnumsAreCompatibleWithProtoEnums_Test.cs" />
     <Compile Include="ComInterfaceAttributes_Test.cs" />
+    <Compile Include="NullifyEmptyStringProperties_Test.cs" />
     <Compile Include="TaskAsyncronousPattern_Test.cs" />
     <Compile Include="XmlSerialization_Test.cs" />
   </ItemGroup>

--- a/tests/NullifyEmptyStringProperties_Test.cs
+++ b/tests/NullifyEmptyStringProperties_Test.cs
@@ -1,0 +1,89 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using NUnit.Framework;
+
+namespace Diadoc.Api.Tests
+{
+	[TestFixture]
+	public class NullifyEmptyStringPropertiesSerialization_Test
+	{
+		[Test]
+		public void Test()
+		{
+			var actual = new NullifyPropertiesTestData
+			{
+				PublicProperty = "",
+				ObjectProperty = new object(),
+				EnumProperty = TestEnum.One,
+				ComplexProperty = new NullifyPropertiesTestData
+				{
+					PublicProperty = "",
+				},
+				ComplexPropertyArray = new[]
+				{
+					new NullifyPropertiesTestData
+					{
+						PublicProperty = "",
+						BoolProperty = true
+					},
+					new NullifyPropertiesTestData
+					{
+						PublicProperty = "",
+					},
+					new NullifyPropertiesTestData
+					{
+						PublicProperty = "123",
+					}
+				}
+			};
+
+			var expected = new NullifyPropertiesTestData
+			{
+				PublicProperty = null,
+				ObjectProperty = new object(),
+				EnumProperty = TestEnum.One,
+				ComplexProperty = new NullifyPropertiesTestData
+				{
+					PublicProperty = null,
+				},
+				ComplexPropertyArray = new[]
+				{
+					new NullifyPropertiesTestData
+					{
+						PublicProperty = null,
+						BoolProperty = true,
+					},
+					new NullifyPropertiesTestData
+					{
+						PublicProperty = null,
+					},
+					new NullifyPropertiesTestData
+					{
+						PublicProperty = "123",
+					}
+				}
+			};
+
+			var actualXml = Encoding.UTF8.GetString(actual.NullifyEmptyStringPropertiesAndSerializeToXml());
+			var expectedXml = Encoding.UTF8.GetString(expected.NullifyEmptyStringPropertiesAndSerializeToXml());
+			Assert.That(actualXml, Is.EqualTo(expectedXml));
+		}
+	}
+
+
+	[SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
+	public class NullifyPropertiesTestData
+	{
+		public string PublicProperty { get; set; }
+		public bool BoolProperty { get; set; }
+		public object ObjectProperty { get; set; }
+		public TestEnum EnumProperty { get; set; }
+		public NullifyPropertiesTestData ComplexProperty { get; set; }
+		public NullifyPropertiesTestData[] ComplexPropertyArray { get; set; }
+	}
+
+	public enum TestEnum
+	{
+		One,
+	}
+}


### PR DESCRIPTION
Привет!

Речь идет о вызове метода API `GenerateSenderTitleXml` и контрактах (например `Diadoc.Api.DataXml.Utd820.UniversalTransferDocument`).

Как хочется их использовать (упрощенно):
```
UniversalTransferDocument utd = CreateUniversalTransferDocumentContract();
var serialized = XmlSerializerExtensions.SerializeToXml(utd)
GeneratedFile result = DiadocApi.GenerateSenderTitleXml(..., userContract: serialized)
```

На такой вызов API мы, скорее всего, получим такую ошибку:
`The value '' is invalid according to its datatype 'string1000' - The actual length is less than the MinLength value`
Потому что какие-то поля в структуре мы заполнили как `""` вместо `null`. 
К сожалению, наше приложение устроено так, что будет очень сложно недопустить попадание пустых строк в контракт. Поэтому сейчас мы пользуемся контрактами так:
```
UniversalTransferDocument utd = CreateUniversalTransferDocumentContract();
NullifyEmptyStrinProperties(utd);
var serialized = XmlSerializerExtensions.SerializeToXml(utd)
GeneratedFile result = DiadocApi.GenerateSenderTitleXml(..., userContractData: serialized)
```
где `NullifyEmptyStringProperties` заменяет все пустые строки в свойствах на `null`.

Поскольку API Диадока не принимает пустые строковые поля, кажется полезным, если `NullifyEmptyStringProperties` будет где-то в SDK. Как минимум, для нашей команды :)

Прошу рассмотреть пулл реквест или помочь придумать другое решение для проблемы.
Хочется сначала получить принципиальное согласие, а потом я допилю метод (добавлю производительности и покрою побольше случаев).




