### PR TITLE
Add TotalCountType to CounteragentList

### DIFF
--- a/Samples/Diadoc.Console/Properties/AssemblyVersion.cs
+++ b/Samples/Diadoc.Console/Properties/AssemblyVersion.cs
@@ -6,6 +6,6 @@
 using System.Reflection;
 
 [assembly: AssemblyVersion("2.9.0.0")]
-[assembly: AssemblyFileVersion("2.9.25-dev")]
-[assembly: AssemblyInformationalVersion("2.9.25-dev")]
+[assembly: AssemblyFileVersion("2.9.27-dev")]
+[assembly: AssemblyInformationalVersion("2.9.27-dev")]
 

--- a/Samples/Diadoc.Samples/Properties/AssemblyVersion.cs
+++ b/Samples/Diadoc.Samples/Properties/AssemblyVersion.cs
@@ -6,6 +6,6 @@
 using System.Reflection;
 
 [assembly: AssemblyVersion("2.9.0.0")]
-[assembly: AssemblyFileVersion("2.9.25-dev")]
-[assembly: AssemblyInformationalVersion("2.9.25-dev")]
+[assembly: AssemblyFileVersion("2.9.27-dev")]
+[assembly: AssemblyInformationalVersion("2.9.27-dev")]
 

--- a/proto/Counteragent.proto
+++ b/proto/Counteragent.proto
@@ -1,11 +1,13 @@
 import "Organization.proto";
 import "DocumentId.proto";
+import "TotalCountType.proto";
 
 package Diadoc.Api.Proto;
 
 message CounteragentList {
 	required int32 TotalCount = 1;
 	repeated Counteragent Counteragents = 2;
+	required TotalCountType TotalCountType = 3;
 }
 
 message Counteragent {

--- a/src/Properties/AssemblyVersion.cs
+++ b/src/Properties/AssemblyVersion.cs
@@ -6,6 +6,6 @@
 using System.Reflection;
 
 [assembly: AssemblyVersion("2.9.0.0")]
-[assembly: AssemblyFileVersion("2.9.25-dev")]
-[assembly: AssemblyInformationalVersion("2.9.25-dev")]
+[assembly: AssemblyFileVersion("2.9.27-dev")]
+[assembly: AssemblyInformationalVersion("2.9.27-dev")]
 

--- a/src/Proto/Counteragent.cs
+++ b/src/Proto/Counteragent.cs
@@ -10,6 +10,7 @@ namespace Diadoc.Api.Proto
 	{
 		int TotalCount { get; }
 		ReadonlyList CounteragentsList { get; }
+		Com.TotalCountType TotalCountTypeValue { get; }
 	}
 
 	[ComVisible(true)]
@@ -21,6 +22,11 @@ namespace Diadoc.Api.Proto
 		public ReadonlyList CounteragentsList
 		{
 			get { return new ReadonlyList(Counteragents); }
+		}
+
+		public Com.TotalCountType TotalCountTypeValue
+		{
+			get { return (Com.TotalCountType) TotalCountType; }
 		}
 
 		public override string ToString()

--- a/src/Proto/Counteragent.proto.cs
+++ b/src/Proto/Counteragent.proto.cs
@@ -10,6 +10,7 @@
 // Generated from: Counteragent.proto
 // Note: requires additional types generated from: Organization.proto
 // Note: requires additional types generated from: DocumentId.proto
+// Note: requires additional types generated from: TotalCountType.proto
 namespace Diadoc.Api.Proto
 {
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"CounteragentList")]
@@ -31,6 +32,13 @@ namespace Diadoc.Api.Proto
       get { return _Counteragents; }
     }
   
+    private Diadoc.Api.Proto.TotalCountType _TotalCountType;
+    [global::ProtoBuf.ProtoMember(3, IsRequired = true, Name=@"TotalCountType", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
+    public Diadoc.Api.Proto.TotalCountType TotalCountType
+    {
+      get { return _TotalCountType; }
+      set { _TotalCountType = value; }
+    }
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }


### PR DESCRIPTION
For now we show a real `TotalCount` for `CounteragentList`. But it hits performance when the total count is huge (thousands and more). Like a documents list and document events list we are going to restrict a size of `TotalCount` by 10 000. If a box has more counteragents the API will return 10 000 and a new field `TotalCountType` will be equal `GreaterThanOrEqual`