### PR TITLE
DDS-58183: Add missing DocumentType - MesNotification

### DIFF
--- a/proto/DocumentType.proto
+++ b/proto/DocumentType.proto
@@ -24,6 +24,7 @@ enum DocumentType
 	SupplementaryAgreement = 40;
 	UniversalTransferDocument = 41;
 	UniversalTransferDocumentRevision = 45;
+	MesNotification = 46;
 	UniversalCorrectionDocument = 49;
 	UniversalCorrectionDocumentRevision = 50;
 }

--- a/src/Com/DocumentType.cs
+++ b/src/Com/DocumentType.cs
@@ -31,6 +31,7 @@ namespace Diadoc.Api.Com
 		SupplementaryAgreement = 40,
 		UniversalTransferDocument = 41,
 		UniversalTransferDocumentRevision = 45,
+		MesNotification = 46,
 		UniversalCorrectionDocument = 49,
 		UniversalCorrectionDocumentRevision = 50,
 	}

--- a/src/Proto/DocumentType.proto.cs
+++ b/src/Proto/DocumentType.proto.cs
@@ -80,6 +80,9 @@ namespace Diadoc.Api.Proto
       [global::ProtoBuf.ProtoEnum(Name=@"UniversalTransferDocumentRevision", Value=45)]
       UniversalTransferDocumentRevision = 45,
             
+      [global::ProtoBuf.ProtoEnum(Name=@"MesNotification", Value=46)]
+      MesNotification = 46,
+            
       [global::ProtoBuf.ProtoEnum(Name=@"UniversalCorrectionDocument", Value=49)]
       UniversalCorrectionDocument = 49,
             


### PR DESCRIPTION
Adds a MesNotification document type which, for some reason, was not added to the SDK earlier