### PR TITLE
Add OIDC authentication

### DIFF
--- a/src/ComDiadocApi.cs
+++ b/src/ComDiadocApi.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Security;
 using Diadoc.Api.Com;
+using Diadoc.Api.Constants;
 using Diadoc.Api.Cryptography;
 using Diadoc.Api.Http;
 using Diadoc.Api.Proto;
@@ -56,18 +57,30 @@ namespace Diadoc.Api
 		ReadonlyList GetOrganizationUsers(string authToken, string orgId);
 		ReadonlyList GetOrganizationUsersV2(string authToken, string boxId);
 		ReadonlyList GetMyOrganizations(string authToken, bool autoRegister = true);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		ReadonlyList GetOrganizationsByInnKpp(string inn, string kpp);
+		ReadonlyList GetOrganizationsByInnKpp(string authToken, string inn, string kpp);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Organization GetOrganizationById(string orgId);
+		Organization GetOrganizationById(string authToken, string orgId);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Organization GetOrganizationByInn(string inn);
+		Organization GetOrganizationByInn(string authToken, string inn);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		ReadonlyList GetOrganizationsByInnList([MarshalAs(UnmanagedType.IDispatch)] object innList);
+		ReadonlyList GetOrganizationsByInnList(string authToken, [MarshalAs(UnmanagedType.IDispatch)] object innList);
 
 		ReadonlyList GetOrganizationsByInnList(
 			string authToken,
 			string myOrgId,
 			[MarshalAs(UnmanagedType.IDispatch)] object innList);
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Organization GetOrganizationByFnsParticipantId(string fnsParticipantId);
+		Organization GetOrganizationByFnsParticipantId(string authToken, string fnsParticipantId);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Box GetBox(string boxId);
+		Box GetBox(string authToken, string boxId);
 		Department GetDepartment(string authToken, string orgId, string departmentId);
 
 		BoxEventList GetNewEvents(
@@ -358,9 +371,15 @@ namespace Diadoc.Api
 
 		string UploadFileToShelf(string authToken, string fileName);
 		void GetFileFromShelf(string authToken, string nameOnShelf, string fileName);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		RussianAddress ParseRussianAddress(string address);
+		RussianAddress ParseRussianAddress(string authToken, string address);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		InvoiceInfo ParseInvoiceXml(byte[] invoiceXmlContent);
+		InvoiceInfo ParseInvoiceXml(string authToken, byte[] invoiceXmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		InvoiceInfo ParseInvoiceXmlFromFile(string fileName);
+		InvoiceInfo ParseInvoiceXmlFromFile(string authToken, string fileName);
 
 		[Obsolete("Use GenerateReceiptXmlV2()")]
 		GeneratedFile GenerateDocumentReceiptXml(
@@ -383,30 +402,78 @@ namespace Diadoc.Api
 			string boxId,
 			[MarshalAs(UnmanagedType.IDispatch)] object receiptGenerationRequest);
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Torg12SellerTitleInfo ParseTorg12SellerTitleXml(byte[] torg12SellerTitleXmlContent);
+		Torg12SellerTitleInfo ParseTorg12SellerTitleXml(string authToken, byte[] torg12SellerTitleXmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Torg12SellerTitleInfo ParseTorg12SellerTitleXmlFromFile(string fileName);
+		Torg12SellerTitleInfo ParseTorg12SellerTitleXmlFromFile(string authToken, string fileName);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Torg12BuyerTitleInfo ParseTorg12BuyerTitleXml(byte[] content);
+		Torg12BuyerTitleInfo ParseTorg12BuyerTitleXml(string authToken, byte[] content);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Torg12BuyerTitleInfo ParseTorg12BuyerTitleXmlFromFile(string fileName);
+		Torg12BuyerTitleInfo ParseTorg12BuyerTitleXmlFromFile(string authToken, string fileName);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		TovTorgSellerTitleInfo ParseTovTorg551SellerTitleXml(byte[] torg12SellerTitleXmlContent);
+		TovTorgSellerTitleInfo ParseTovTorg551SellerTitleXml(string authToken, byte[] torg12SellerTitleXmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		TovTorgSellerTitleInfo ParseTovTorg551SellerTitleXmlFromFile(string fileName);
+		TovTorgSellerTitleInfo ParseTovTorg551SellerTitleXmlFromFile(string authToken, string fileName);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		TovTorgBuyerTitleInfo ParseTovTorg551BuyerTitleXml(byte[] content);
+		TovTorgBuyerTitleInfo ParseTovTorg551BuyerTitleXml(string authToken, byte[] content);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		TovTorgBuyerTitleInfo ParseTovTorg551BuyerTitleXmlFromFile(string fileName);
+		TovTorgBuyerTitleInfo ParseTovTorg551BuyerTitleXmlFromFile(string authToken, string fileName);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		AcceptanceCertificateSellerTitleInfo ParseAcceptanceCertificateSellerTitleXml(byte[] xmlContent);
+		AcceptanceCertificateSellerTitleInfo ParseAcceptanceCertificateSellerTitleXml(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		AcceptanceCertificateSellerTitleInfo ParseAcceptanceCertificateSellerTitleXmlFromFile(string fileName);
+		AcceptanceCertificateSellerTitleInfo ParseAcceptanceCertificateSellerTitleXmlFromFile(string authToken, string fileName);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		AcceptanceCertificateBuyerTitleInfo ParseAcceptanceCertificateBuyerTitleXml(byte[] xmlContent);
+		AcceptanceCertificateBuyerTitleInfo ParseAcceptanceCertificateBuyerTitleXml(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		AcceptanceCertificateBuyerTitleInfo ParseAcceptanceCertificateBuyerTitleXmlFromFile(string fileName);
+		AcceptanceCertificateBuyerTitleInfo ParseAcceptanceCertificateBuyerTitleXmlFromFile(string authToken, string fileName);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		AcceptanceCertificate552SellerTitleInfo ParseAcceptanceCertificate552SellerTitleXml(byte[] xmlContent);
+		AcceptanceCertificate552SellerTitleInfo ParseAcceptanceCertificate552SellerTitleXml(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		AcceptanceCertificate552SellerTitleInfo ParseAcceptanceCertificate552SellerTitleXmlFromFile(string fileName);
+		AcceptanceCertificate552SellerTitleInfo ParseAcceptanceCertificate552SellerTitleXmlFromFile(string authToken, string fileName);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		AcceptanceCertificate552BuyerTitleInfo ParseAcceptanceCertificate552BuyerTitleXml(byte[] xmlContent);
+		AcceptanceCertificate552BuyerTitleInfo ParseAcceptanceCertificate552BuyerTitleXml(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		AcceptanceCertificate552BuyerTitleInfo ParseAcceptanceCertificate552BuyerTitleXmlFromFile(string fileName);
+		AcceptanceCertificate552BuyerTitleInfo ParseAcceptanceCertificate552BuyerTitleXmlFromFile(string authToken, string fileName);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		UniversalTransferDocumentSellerTitleInfo ParseUniversalTransferDocumentSellerTitleXml(byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Utd);
+		UniversalTransferDocumentSellerTitleInfo ParseUniversalTransferDocumentSellerTitleXml(string authToken, byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Utd);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		UniversalTransferDocumentSellerTitleInfo ParseUniversalTransferDocumentSellerTitleXmlFromFile(string fileName, string documentVersion = DefaultDocumentVersions.Utd);
+		UniversalTransferDocumentSellerTitleInfo ParseUniversalTransferDocumentSellerTitleXmlFromFile(string authToken, string fileName, string documentVersion = DefaultDocumentVersions.Utd);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		UniversalTransferDocumentBuyerTitleInfo ParseUniversalTransferDocumentBuyerTitleXml(byte[] xmlContent);
+		UniversalTransferDocumentBuyerTitleInfo ParseUniversalTransferDocumentBuyerTitleXml(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		UniversalTransferDocumentBuyerTitleInfo ParseUniversalTransferDocumentBuyerTitleXmlFromFile(string fileName);
+		UniversalTransferDocumentBuyerTitleInfo ParseUniversalTransferDocumentBuyerTitleXmlFromFile(string authToken, string fileName);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		UniversalCorrectionDocumentSellerTitleInfo ParseUniversalCorrectionDocumentSellerTitleXml(byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Ucd);
+		UniversalCorrectionDocumentSellerTitleInfo ParseUniversalCorrectionDocumentSellerTitleXml(string authToken, byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Ucd);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		UniversalCorrectionDocumentSellerTitleInfo ParseUniversalCorrectionDocumentSellerTitleXmlFromFile(string fileName, string documentVersion = DefaultDocumentVersions.Ucd);
+		UniversalCorrectionDocumentSellerTitleInfo ParseUniversalCorrectionDocumentSellerTitleXmlFromFile(string authToken, string fileName, string documentVersion = DefaultDocumentVersions.Ucd);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		UniversalTransferDocumentBuyerTitleInfo ParseUniversalCorrectionDocumentBuyerTitleXml(byte[] xmlContent);
+		UniversalTransferDocumentBuyerTitleInfo ParseUniversalCorrectionDocumentBuyerTitleXml(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		UniversalTransferDocumentBuyerTitleInfo ParseUniversalCorrectionDocumentBuyerTitleXmlFromFile(string fileName);
+		UniversalTransferDocumentBuyerTitleInfo ParseUniversalCorrectionDocumentBuyerTitleXmlFromFile(string authToken, string fileName);
 
 		byte[] ParseTitleXml(
 			string authToken,
@@ -438,12 +505,24 @@ namespace Diadoc.Api
 			string boxId,
 			[MarshalAs(UnmanagedType.IDispatch)] object signatureRejectionGenerationRequest);
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		RevocationRequestInfo ParseRevocationRequestXml(byte[] revocationRequestXmlContent);
+		RevocationRequestInfo ParseRevocationRequestXml(string authToken, byte[] revocationRequestXmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		RevocationRequestInfo ParseRevocationRequestXmlFromFile(string fileName);
+		RevocationRequestInfo ParseRevocationRequestXmlFromFile(string authToken, string fileName);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		SignatureRejectionInfo ParseSignatureRejectionXml(byte[] signatureRejectionXmlContent);
+		SignatureRejectionInfo ParseSignatureRejectionXml(string authToken, byte[] signatureRejectionXmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		SignatureRejectionInfo ParseSignatureRejectionXmlFromFile(string fileName);
+		SignatureRejectionInfo ParseSignatureRejectionXmlFromFile(string authToken, string fileName);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Organization GetOrganizationByBoxId(string boxId);
+		Organization GetOrganizationByBoxId(string authToken, string boxId);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Organization GetOrganizationByInnKpp(string inn, string kpp);
+		Organization GetOrganizationByInnKpp(string authToken, string inn, string kpp);
 		IDocumentProtocolResult GenerateDocumentProtocol(string authToken, string boxId, string messageId, string documentId);
 
 		GetForwardedDocumentsResponse GetForwardedDocuments(
@@ -714,9 +793,19 @@ namespace Diadoc.Api
 			return new ReadonlyList(diadoc.GetOrganizationsByInnKpp(inn, kpp).Organizations);
 		}
 
+		public ReadonlyList GetOrganizationsByInnKpp(string authToken, string inn, string kpp)
+		{
+			return new ReadonlyList(diadoc.GetOrganizationsByInnKpp(authToken, inn, kpp).Organizations);
+		}
+
 		public Organization GetOrganizationById(string orgId)
 		{
 			return diadoc.GetOrganizationById(orgId);
+		}
+
+		public Organization GetOrganizationById(string authToken, string orgId)
+		{
+			return diadoc.GetOrganizationById(authToken, orgId);
 		}
 
 		public Organization GetOrganizationByInn(string inn)
@@ -724,9 +813,19 @@ namespace Diadoc.Api
 			return diadoc.GetOrganizationByInnKpp(inn, kpp: null);
 		}
 
+		public Organization GetOrganizationByInn(string authToken, string inn)
+		{
+			return diadoc.GetOrganizationByInnKpp(authToken, inn, kpp: null);
+		}
+
 		public Organization GetOrganizationByBoxId(string boxId)
 		{
 			return diadoc.GetOrganizationByBoxId(boxId);
+		}
+
+		public Organization GetOrganizationByBoxId(string authToken, string boxId)
+		{
+			return diadoc.GetOrganizationByBoxId(authToken, boxId);
 		}
 
 		public Organization GetOrganizationByFnsParticipantId(string fnsParticipantId)
@@ -734,9 +833,19 @@ namespace Diadoc.Api
 			return diadoc.GetOrganizationByFnsParticipantId(fnsParticipantId);
 		}
 
+		public Organization GetOrganizationByFnsParticipantId(string authToken, string fnsParticipantId)
+		{
+			return diadoc.GetOrganizationByFnsParticipantId(authToken, fnsParticipantId);
+		}
+
 		public Organization GetOrganizationByInnKpp(string inn, string kpp)
 		{
 			return diadoc.GetOrganizationByInnKpp(inn, kpp);
+		}
+
+		public Organization GetOrganizationByInnKpp(string authToken, string inn, string kpp)
+		{
+			return diadoc.GetOrganizationByInnKpp(authToken, inn, kpp);
 		}
 
 		public IDocumentProtocolResult GenerateDocumentProtocol(
@@ -753,6 +862,11 @@ namespace Diadoc.Api
 			return new ReadonlyList(diadoc.GetOrganizationsByInnList((GetOrganizationsByInnListRequest) innList));
 		}
 
+		public ReadonlyList GetOrganizationsByInnList(string authToken, object innList)
+		{
+			return new ReadonlyList(diadoc.GetOrganizationsByInnList(authToken, (GetOrganizationsByInnListRequest) innList));
+		}
+
 		public ReadonlyList GetOrganizationsByInnList(string authToken, string myOrgId, object innList)
 		{
 			return
@@ -762,6 +876,11 @@ namespace Diadoc.Api
 		public Box GetBox(string boxId)
 		{
 			return diadoc.GetBox(boxId);
+		}
+
+		public Box GetBox(string authToken, string boxId)
+		{
+			return diadoc.GetBox(authToken, boxId);
 		}
 
 		public OrganizationFeatures GetOrganizationFeatures(string authToken, string boxId)
@@ -1091,9 +1210,19 @@ namespace Diadoc.Api
 			return diadoc.ParseRevocationRequestXml(revocationRequestXmlContent);
 		}
 
+		public RevocationRequestInfo ParseRevocationRequestXml(string authToken, byte[] revocationRequestXmlContent)
+		{
+			return diadoc.ParseRevocationRequestXml(authToken, revocationRequestXmlContent);
+		}
+
 		public RevocationRequestInfo ParseRevocationRequestXmlFromFile(string fileName)
 		{
 			return ParseRevocationRequestXml(File.ReadAllBytes(fileName));
+		}
+
+		public RevocationRequestInfo ParseRevocationRequestXmlFromFile(string authToken, string fileName)
+		{
+			return ParseRevocationRequestXml(authToken, File.ReadAllBytes(fileName));
 		}
 
 		public SignatureRejectionInfo ParseSignatureRejectionXml(byte[] signatureRejectionXmlContent)
@@ -1101,9 +1230,19 @@ namespace Diadoc.Api
 			return diadoc.ParseSignatureRejectionXml(signatureRejectionXmlContent);
 		}
 
+		public SignatureRejectionInfo ParseSignatureRejectionXml(string authToken, byte[] signatureRejectionXmlContent)
+		{
+			return diadoc.ParseSignatureRejectionXml(authToken, signatureRejectionXmlContent);
+		}
+
 		public SignatureRejectionInfo ParseSignatureRejectionXmlFromFile(string fileName)
 		{
 			return ParseSignatureRejectionXml(File.ReadAllBytes(fileName));
+		}
+
+		public SignatureRejectionInfo ParseSignatureRejectionXmlFromFile(string authToken, string fileName)
+		{
+			return ParseSignatureRejectionXml(authToken, File.ReadAllBytes(fileName));
 		}
 
 		public GeneratedFile GenerateInvoiceXml(string authToken, object invoiceInfo, bool disableValidation = false)
@@ -1932,9 +2071,19 @@ namespace Diadoc.Api
 			return diadoc.ParseRussianAddress(address);
 		}
 
+		public RussianAddress ParseRussianAddress(string authToken, string address)
+		{
+			return diadoc.ParseRussianAddress(authToken, address);
+		}
+
 		public InvoiceInfo ParseInvoiceXml(byte[] invoiceXmlContent)
 		{
 			return diadoc.ParseInvoiceXml(invoiceXmlContent);
+		}
+
+		public InvoiceInfo ParseInvoiceXml(string authToken, byte[] invoiceXmlContent)
+		{
+			return diadoc.ParseInvoiceXml(authToken, invoiceXmlContent);
 		}
 
 		public InvoiceInfo ParseInvoiceXmlFromFile(string fileName)
@@ -1942,9 +2091,19 @@ namespace Diadoc.Api
 			return ParseInvoiceXml(File.ReadAllBytes(fileName));
 		}
 
+		public InvoiceInfo ParseInvoiceXmlFromFile(string authToken, string fileName)
+		{
+			return ParseInvoiceXml(authToken, File.ReadAllBytes(fileName));
+		}
+
 		public Torg12SellerTitleInfo ParseTorg12SellerTitleXml(byte[] torg12SellerTitleXmlContent)
 		{
 			return diadoc.ParseTorg12SellerTitleXml(torg12SellerTitleXmlContent);
+		}
+
+		public Torg12SellerTitleInfo ParseTorg12SellerTitleXml(string authToken, byte[] torg12SellerTitleXmlContent)
+		{
+			return diadoc.ParseTorg12SellerTitleXml(authToken, torg12SellerTitleXmlContent);
 		}
 
 		public Torg12SellerTitleInfo ParseTorg12SellerTitleXmlFromFile(string fileName)
@@ -1952,9 +2111,19 @@ namespace Diadoc.Api
 			return ParseTorg12SellerTitleXml(File.ReadAllBytes(fileName));
 		}
 
+		public Torg12SellerTitleInfo ParseTorg12SellerTitleXmlFromFile(string authToken, string fileName)
+		{
+			return ParseTorg12SellerTitleXml(authToken, File.ReadAllBytes(fileName));
+		}
+
 		public Torg12BuyerTitleInfo ParseTorg12BuyerTitleXml(byte[] content)
 		{
 			return diadoc.ParseTorg12BuyerTitleXml(content);
+		}
+
+		public Torg12BuyerTitleInfo ParseTorg12BuyerTitleXml(string authToken, byte[] content)
+		{
+			return diadoc.ParseTorg12BuyerTitleXml(authToken, content);
 		}
 
 		public Torg12BuyerTitleInfo ParseTorg12BuyerTitleXmlFromFile(string fileName)
@@ -1962,9 +2131,19 @@ namespace Diadoc.Api
 			return ParseTorg12BuyerTitleXml(File.ReadAllBytes(fileName));
 		}
 
+		public Torg12BuyerTitleInfo ParseTorg12BuyerTitleXmlFromFile(string authToken, string fileName)
+		{
+			return ParseTorg12BuyerTitleXml(authToken, File.ReadAllBytes(fileName));
+		}
+
 		public TovTorgSellerTitleInfo ParseTovTorg551SellerTitleXml(byte[] torg12SellerTitleXmlContent)
 		{
 			return diadoc.ParseTovTorg551SellerTitleXml(torg12SellerTitleXmlContent);
+		}
+
+		public TovTorgSellerTitleInfo ParseTovTorg551SellerTitleXml(string authToken, byte[] torg12SellerTitleXmlContent)
+		{
+			return diadoc.ParseTovTorg551SellerTitleXml(authToken, torg12SellerTitleXmlContent);
 		}
 
 		public TovTorgSellerTitleInfo ParseTovTorg551SellerTitleXmlFromFile(string fileName)
@@ -1972,9 +2151,19 @@ namespace Diadoc.Api
 			return ParseTovTorg551SellerTitleXml(File.ReadAllBytes(fileName));
 		}
 
+		public TovTorgSellerTitleInfo ParseTovTorg551SellerTitleXmlFromFile(string authToken, string fileName)
+		{
+			return ParseTovTorg551SellerTitleXml(authToken, File.ReadAllBytes(fileName));
+		}
+
 		public TovTorgBuyerTitleInfo ParseTovTorg551BuyerTitleXml(byte[] content)
 		{
 			return diadoc.ParseTovTorg551BuyerTitleXml(content);
+		}
+
+		public TovTorgBuyerTitleInfo ParseTovTorg551BuyerTitleXml(string authToken, byte[] content)
+		{
+			return diadoc.ParseTovTorg551BuyerTitleXml(authToken, content);
 		}
 
 		public TovTorgBuyerTitleInfo ParseTovTorg551BuyerTitleXmlFromFile(string fileName)
@@ -1982,9 +2171,19 @@ namespace Diadoc.Api
 			return ParseTovTorg551BuyerTitleXml(File.ReadAllBytes(fileName));
 		}
 
+		public TovTorgBuyerTitleInfo ParseTovTorg551BuyerTitleXmlFromFile(string authToken, string fileName)
+		{
+			return ParseTovTorg551BuyerTitleXml(authToken, File.ReadAllBytes(fileName));
+		}
+
 		public AcceptanceCertificateSellerTitleInfo ParseAcceptanceCertificateSellerTitleXml(byte[] xmlContent)
 		{
 			return diadoc.ParseAcceptanceCertificateSellerTitleXml(xmlContent);
+		}
+
+		public AcceptanceCertificateSellerTitleInfo ParseAcceptanceCertificateSellerTitleXml(string authToken, byte[] xmlContent)
+		{
+			return diadoc.ParseAcceptanceCertificateSellerTitleXml(authToken, xmlContent);
 		}
 
 		public AcceptanceCertificateSellerTitleInfo ParseAcceptanceCertificateSellerTitleXmlFromFile(string fileName)
@@ -1992,9 +2191,19 @@ namespace Diadoc.Api
 			return ParseAcceptanceCertificateSellerTitleXml(File.ReadAllBytes(fileName));
 		}
 
+		public AcceptanceCertificateSellerTitleInfo ParseAcceptanceCertificateSellerTitleXmlFromFile(string authToken, string fileName)
+		{
+			return ParseAcceptanceCertificateSellerTitleXml(authToken, File.ReadAllBytes(fileName));
+		}
+
 		public AcceptanceCertificateBuyerTitleInfo ParseAcceptanceCertificateBuyerTitleXml(byte[] xmlContent)
 		{
 			return diadoc.ParseAcceptanceCertificateBuyerTitleXml(xmlContent);
+		}
+
+		public AcceptanceCertificateBuyerTitleInfo ParseAcceptanceCertificateBuyerTitleXml(string authToken, byte[] xmlContent)
+		{
+			return diadoc.ParseAcceptanceCertificateBuyerTitleXml(authToken, xmlContent);
 		}
 
 		public AcceptanceCertificateBuyerTitleInfo ParseAcceptanceCertificateBuyerTitleXmlFromFile(string fileName)
@@ -2002,9 +2211,19 @@ namespace Diadoc.Api
 			return ParseAcceptanceCertificateBuyerTitleXml(File.ReadAllBytes(fileName));
 		}
 
+		public AcceptanceCertificateBuyerTitleInfo ParseAcceptanceCertificateBuyerTitleXmlFromFile(string authToken, string fileName)
+		{
+			return ParseAcceptanceCertificateBuyerTitleXml(authToken, File.ReadAllBytes(fileName));
+		}
+
 		public AcceptanceCertificate552SellerTitleInfo ParseAcceptanceCertificate552SellerTitleXml(byte[] xmlContent)
 		{
 			return diadoc.ParseAcceptanceCertificate552SellerTitleXml(xmlContent);
+		}
+
+		public AcceptanceCertificate552SellerTitleInfo ParseAcceptanceCertificate552SellerTitleXml(string authToken, byte[] xmlContent)
+		{
+			return diadoc.ParseAcceptanceCertificate552SellerTitleXml(authToken, xmlContent);
 		}
 
 		public AcceptanceCertificate552SellerTitleInfo ParseAcceptanceCertificate552SellerTitleXmlFromFile(string fileName)
@@ -2012,9 +2231,19 @@ namespace Diadoc.Api
 			return ParseAcceptanceCertificate552SellerTitleXml(File.ReadAllBytes(fileName));
 		}
 
+		public AcceptanceCertificate552SellerTitleInfo ParseAcceptanceCertificate552SellerTitleXmlFromFile(string authToken, string fileName)
+		{
+			return ParseAcceptanceCertificate552SellerTitleXml(authToken, File.ReadAllBytes(fileName));
+		}
+
 		public AcceptanceCertificate552BuyerTitleInfo ParseAcceptanceCertificate552BuyerTitleXml(byte[] xmlContent)
 		{
 			return diadoc.ParseAcceptanceCertificate552BuyerTitleXml(xmlContent);
+		}
+
+		public AcceptanceCertificate552BuyerTitleInfo ParseAcceptanceCertificate552BuyerTitleXml(string authToken, byte[] xmlContent)
+		{
+			return diadoc.ParseAcceptanceCertificate552BuyerTitleXml(authToken, xmlContent);
 		}
 
 		public AcceptanceCertificate552BuyerTitleInfo ParseAcceptanceCertificate552BuyerTitleXmlFromFile(string fileName)
@@ -2022,9 +2251,19 @@ namespace Diadoc.Api
 			return ParseAcceptanceCertificate552BuyerTitleXml(File.ReadAllBytes(fileName));
 		}
 
+		public AcceptanceCertificate552BuyerTitleInfo ParseAcceptanceCertificate552BuyerTitleXmlFromFile(string authToken, string fileName)
+		{
+			return ParseAcceptanceCertificate552BuyerTitleXml(authToken, File.ReadAllBytes(fileName));
+		}
+
 		public UniversalTransferDocumentSellerTitleInfo ParseUniversalTransferDocumentSellerTitleXml(byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Utd)
 		{
 			return diadoc.ParseUniversalTransferDocumentSellerTitleXml(xmlContent, documentVersion);
+		}
+
+		public UniversalTransferDocumentSellerTitleInfo ParseUniversalTransferDocumentSellerTitleXml(string authToken, byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Utd)
+		{
+			return diadoc.ParseUniversalTransferDocumentSellerTitleXml(authToken, xmlContent, documentVersion);
 		}
 
 		public UniversalTransferDocumentSellerTitleInfo ParseUniversalTransferDocumentSellerTitleXmlFromFile(string fileName, string documentVersion = DefaultDocumentVersions.Utd)
@@ -2032,9 +2271,19 @@ namespace Diadoc.Api
 			return ParseUniversalTransferDocumentSellerTitleXml(File.ReadAllBytes(fileName), documentVersion);
 		}
 
+		public UniversalTransferDocumentSellerTitleInfo ParseUniversalTransferDocumentSellerTitleXmlFromFile(string authToken, string fileName, string documentVersion = DefaultDocumentVersions.Utd)
+		{
+			return ParseUniversalTransferDocumentSellerTitleXml(authToken, File.ReadAllBytes(fileName), documentVersion);
+		}
+
 		public UniversalTransferDocumentBuyerTitleInfo ParseUniversalTransferDocumentBuyerTitleXml(byte[] xmlContent)
 		{
 			return diadoc.ParseUniversalTransferDocumentBuyerTitleXml(xmlContent);
+		}
+
+		public UniversalTransferDocumentBuyerTitleInfo ParseUniversalTransferDocumentBuyerTitleXml(string authToken, byte[] xmlContent)
+		{
+			return diadoc.ParseUniversalTransferDocumentBuyerTitleXml(authToken, xmlContent);
 		}
 
 		public UniversalTransferDocumentBuyerTitleInfo ParseUniversalTransferDocumentBuyerTitleXmlFromFile(string fileName)
@@ -2042,9 +2291,19 @@ namespace Diadoc.Api
 			return ParseUniversalTransferDocumentBuyerTitleXml(File.ReadAllBytes(fileName));
 		}
 
+		public UniversalTransferDocumentBuyerTitleInfo ParseUniversalTransferDocumentBuyerTitleXmlFromFile(string authToken, string fileName)
+		{
+			return ParseUniversalTransferDocumentBuyerTitleXml(authToken, File.ReadAllBytes(fileName));
+		}
+
 		public UniversalCorrectionDocumentSellerTitleInfo ParseUniversalCorrectionDocumentSellerTitleXml(byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Ucd)
 		{
 			return diadoc.ParseUniversalCorrectionDocumentSellerTitleXml(xmlContent, documentVersion);
+		}
+
+		public UniversalCorrectionDocumentSellerTitleInfo ParseUniversalCorrectionDocumentSellerTitleXml(string authToken, byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Ucd)
+		{
+			return diadoc.ParseUniversalCorrectionDocumentSellerTitleXml(authToken, xmlContent, documentVersion);
 		}
 
 		public UniversalCorrectionDocumentSellerTitleInfo ParseUniversalCorrectionDocumentSellerTitleXmlFromFile(string fileName, string documentVersion = DefaultDocumentVersions.Ucd)
@@ -2052,14 +2311,29 @@ namespace Diadoc.Api
 			return ParseUniversalCorrectionDocumentSellerTitleXml(File.ReadAllBytes(fileName), documentVersion);
 		}
 
+		public UniversalCorrectionDocumentSellerTitleInfo ParseUniversalCorrectionDocumentSellerTitleXmlFromFile(string authToken, string fileName, string documentVersion = DefaultDocumentVersions.Ucd)
+		{
+			return ParseUniversalCorrectionDocumentSellerTitleXml(authToken, File.ReadAllBytes(fileName), documentVersion);
+		}
+
 		public UniversalTransferDocumentBuyerTitleInfo ParseUniversalCorrectionDocumentBuyerTitleXml(byte[] xmlContent)
 		{
 			return diadoc.ParseUniversalCorrectionDocumentBuyerTitleXml(xmlContent);
 		}
 
+		public UniversalTransferDocumentBuyerTitleInfo ParseUniversalCorrectionDocumentBuyerTitleXml(string authToken, byte[] xmlContent)
+		{
+			return diadoc.ParseUniversalCorrectionDocumentBuyerTitleXml(authToken, xmlContent);
+		}
+
 		public UniversalTransferDocumentBuyerTitleInfo ParseUniversalCorrectionDocumentBuyerTitleXmlFromFile(string fileName)
 		{
 			return ParseUniversalCorrectionDocumentBuyerTitleXml(File.ReadAllBytes(fileName));
+		}
+
+		public UniversalTransferDocumentBuyerTitleInfo ParseUniversalCorrectionDocumentBuyerTitleXmlFromFile(string authToken, string fileName)
+		{
+			return ParseUniversalCorrectionDocumentBuyerTitleXml(authToken, File.ReadAllBytes(fileName));
 		}
 
 		public byte[] ParseTitleXml(

--- a/src/Constants/ObsoleteReasons.cs
+++ b/src/Constants/ObsoleteReasons.cs
@@ -1,0 +1,7 @@
+﻿namespace Diadoc.Api.Constants
+{
+	internal static class ObsoleteReasons
+	{
+		public const string UseAuthTokenOverload = "Use overload with authToken argument";
+	}
+}

--- a/src/DiadocApi.Async.cs
+++ b/src/DiadocApi.Async.cs
@@ -134,10 +134,24 @@ namespace Diadoc.Api
 			return diadocHttpApi.GetOrganizationsByInnKppAsync(inn, kpp, includeRelations);
 		}
 
+		public Task<OrganizationList> GetOrganizationsByInnKppAsync(string authToken, string inn, string kpp, bool includeRelations = false)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			if (inn == null) throw new ArgumentNullException(nameof(inn));
+			return diadocHttpApi.GetOrganizationsByInnKppAsync(authToken, inn, kpp, includeRelations);
+		}
+
 		public Task<Organization> GetOrganizationByIdAsync(string orgId)
 		{
 			if (orgId == null) throw new ArgumentNullException("orgId");
 			return diadocHttpApi.GetOrganizationByIdAsync(orgId);
+		}
+
+		public Task<Organization> GetOrganizationByIdAsync(string authToken, string orgId)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			if (orgId == null) throw new ArgumentNullException(nameof(orgId));
+			return diadocHttpApi.GetOrganizationByIdAsync(authToken, orgId);
 		}
 
 		public Task<Organization> GetOrganizationByBoxIdAsync(string boxId)
@@ -146,16 +160,37 @@ namespace Diadoc.Api
 			return diadocHttpApi.GetOrganizationByBoxIdAsync(boxId);
 		}
 
+		public Task<Organization> GetOrganizationByBoxIdAsync(string authToken, string boxId)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			if (boxId == null) throw new ArgumentNullException(nameof(boxId));
+			return diadocHttpApi.GetOrganizationByBoxIdAsync(authToken, boxId);
+		}
+
 		public Task<Organization> GetOrganizationByFnsParticipantIdAsync(string fnsParticipantId)
 		{
 			if (fnsParticipantId == null) throw new ArgumentException("fnsParticipantId");
 			return diadocHttpApi.GetOrganizationByFnsParticipantIdAsync(fnsParticipantId);
 		}
 
+		public Task<Organization> GetOrganizationByFnsParticipantIdAsync(string authToken, string fnsParticipantId)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			if (fnsParticipantId == null) throw new ArgumentNullException(nameof(fnsParticipantId));
+			return diadocHttpApi.GetOrganizationByFnsParticipantIdAsync(authToken, fnsParticipantId);
+		}
+
 		public Task<Organization> GetOrganizationByInnKppAsync(string inn, string kpp)
 		{
 			if (inn == null) throw new ArgumentException("inn");
 			return diadocHttpApi.GetOrganizationByInnKppAsync(inn, kpp);
+		}
+
+		public Task<Organization> GetOrganizationByInnKppAsync(string authToken, string inn, string kpp)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			if (inn == null) throw new ArgumentNullException(nameof(inn));
+			return diadocHttpApi.GetOrganizationByInnKppAsync(authToken, inn, kpp);
 		}
 
 		public Task<RoamingOperatorList> GetRoamingOperatorsAsync(string authToken, string boxId)
@@ -167,6 +202,13 @@ namespace Diadoc.Api
 		{
 			if (boxId == null) throw new ArgumentNullException("boxId");
 			return diadocHttpApi.GetBoxAsync(boxId);
+		}
+
+		public Task<Box> GetBoxAsync(string authToken, string boxId)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			if (boxId == null) throw new ArgumentNullException(nameof(boxId));
+			return diadocHttpApi.GetBoxAsync(authToken, boxId);
 		}
 
 		public Task<Department> GetDepartmentAsync(string authToken, string orgId, string departmentId)
@@ -839,9 +881,21 @@ namespace Diadoc.Api
 			return diadocHttpApi.ParseRussianAddressAsync(address);
 		}
 
+		public Task<RussianAddress> ParseRussianAddressAsync(string authToken, string address)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseRussianAddressAsync(authToken, address);
+		}
+
 		public Task<InvoiceInfo> ParseInvoiceXmlAsync(byte[] invoiceXmlContent)
 		{
 			return diadocHttpApi.ParseInvoiceXmlAsync(invoiceXmlContent);
+		}
+
+		public Task<InvoiceInfo> ParseInvoiceXmlAsync(string authToken, byte[] invoiceXmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseInvoiceXmlAsync(authToken, invoiceXmlContent);
 		}
 
 		public Task<Torg12SellerTitleInfo> ParseTorg12SellerTitleXmlAsync(byte[] xmlContent)
@@ -849,9 +903,21 @@ namespace Diadoc.Api
 			return diadocHttpApi.ParseTorg12SellerTitleXmlAsync(xmlContent);
 		}
 
+		public Task<Torg12SellerTitleInfo> ParseTorg12SellerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseTorg12SellerTitleXmlAsync(authToken, xmlContent);
+		}
+
 		public Task<Torg12BuyerTitleInfo> ParseTorg12BuyerTitleXmlAsync(byte[] xmlContent)
 		{
 			return diadocHttpApi.ParseTorg12BuyerTitleXmlAsync(xmlContent);
+		}
+
+		public Task<Torg12BuyerTitleInfo> ParseTorg12BuyerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseTorg12BuyerTitleXmlAsync(authToken, xmlContent);
 		}
 
 		public Task<TovTorgSellerTitleInfo> ParseTovTorg551SellerTitleXmlAsync(byte[] xmlContent)
@@ -859,9 +925,21 @@ namespace Diadoc.Api
 			return diadocHttpApi.ParseTovTorg551SellerTitleXmlAsync(xmlContent);
 		}
 
+		public Task<TovTorgSellerTitleInfo> ParseTovTorg551SellerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseTovTorg551SellerTitleXmlAsync(authToken, xmlContent);
+		}
+
 		public Task<TovTorgBuyerTitleInfo> ParseTovTorg551BuyerTitleXmlAsync(byte[] xmlContent)
 		{
 			return diadocHttpApi.ParseTovTorg551BuyerTitleXmlAsync(xmlContent);
+		}
+
+		public Task<TovTorgBuyerTitleInfo> ParseTovTorg551BuyerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseTovTorg551BuyerTitleXmlAsync(authToken, xmlContent);
 		}
 
 		public Task<AcceptanceCertificateSellerTitleInfo> ParseAcceptanceCertificateSellerTitleXmlAsync(byte[] xmlContent)
@@ -869,9 +947,21 @@ namespace Diadoc.Api
 			return diadocHttpApi.ParseAcceptanceCertificateSellerTitleXmlAsync(xmlContent);
 		}
 
+		public Task<AcceptanceCertificateSellerTitleInfo> ParseAcceptanceCertificateSellerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseAcceptanceCertificateSellerTitleXmlAsync(authToken, xmlContent);
+		}
+
 		public Task<AcceptanceCertificateBuyerTitleInfo> ParseAcceptanceCertificateBuyerTitleXmlAsync(byte[] xmlContent)
 		{
 			return diadocHttpApi.ParseAcceptanceCertificateBuyerTitleXmlAsync(xmlContent);
+		}
+
+		public Task<AcceptanceCertificateBuyerTitleInfo> ParseAcceptanceCertificateBuyerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseAcceptanceCertificateBuyerTitleXmlAsync(authToken, xmlContent);
 		}
 
 		public Task<AcceptanceCertificate552SellerTitleInfo> ParseAcceptanceCertificate552SellerTitleXmlAsync(byte[] xmlContent)
@@ -879,9 +969,21 @@ namespace Diadoc.Api
 			return diadocHttpApi.ParseAcceptanceCertificate552SellerTitleXmlAsync(xmlContent);
 		}
 
+		public Task<AcceptanceCertificate552SellerTitleInfo> ParseAcceptanceCertificate552SellerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseAcceptanceCertificate552SellerTitleXmlAsync(authToken, xmlContent);
+		}
+
 		public Task<AcceptanceCertificate552BuyerTitleInfo> ParseAcceptanceCertificate552BuyerTitleXmlAsync(byte[] xmlContent)
 		{
 			return diadocHttpApi.ParseAcceptanceCertificate552BuyerTitleXmlAsync(xmlContent);
+		}
+
+		public Task<AcceptanceCertificate552BuyerTitleInfo> ParseAcceptanceCertificate552BuyerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseAcceptanceCertificate552BuyerTitleXmlAsync(authToken, xmlContent);
 		}
 
 		public Task<UniversalTransferDocumentSellerTitleInfo> ParseUniversalTransferDocumentSellerTitleXmlAsync(byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Utd)
@@ -889,9 +991,21 @@ namespace Diadoc.Api
 			return diadocHttpApi.ParseUniversalTransferDocumentSellerTitleXmlAsync(xmlContent, documentVersion);
 		}
 
+		public Task<UniversalTransferDocumentSellerTitleInfo> ParseUniversalTransferDocumentSellerTitleXmlAsync(string authToken, byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Utd)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseUniversalTransferDocumentSellerTitleXmlAsync(authToken, xmlContent, documentVersion);
+		}
+
 		public Task<UniversalTransferDocumentBuyerTitleInfo> ParseUniversalTransferDocumentBuyerTitleXmlAsync(byte[] xmlContent)
 		{
 			return diadocHttpApi.ParseUniversalTransferDocumentBuyerTitleXmlAsync(xmlContent);
+		}
+
+		public Task<UniversalTransferDocumentBuyerTitleInfo> ParseUniversalTransferDocumentBuyerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseUniversalTransferDocumentBuyerTitleXmlAsync(authToken, xmlContent);
 		}
 
 		public Task<UniversalCorrectionDocumentSellerTitleInfo> ParseUniversalCorrectionDocumentSellerTitleXmlAsync(byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Ucd)
@@ -899,9 +1013,21 @@ namespace Diadoc.Api
 			return diadocHttpApi.ParseUniversalCorrectionDocumentSellerTitleXmlAsync(xmlContent, documentVersion);
 		}
 
+		public Task<UniversalCorrectionDocumentSellerTitleInfo> ParseUniversalCorrectionDocumentSellerTitleXmlAsync(string authToken, byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Ucd)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseUniversalCorrectionDocumentSellerTitleXmlAsync(authToken, xmlContent, documentVersion);
+		}
+
 		public Task<UniversalTransferDocumentBuyerTitleInfo> ParseUniversalCorrectionDocumentBuyerTitleXmlAsync(byte[] xmlContent)
 		{
 			return diadocHttpApi.ParseUniversalCorrectionDocumentBuyerTitleXmlAsync(xmlContent);
+		}
+
+		public Task<UniversalTransferDocumentBuyerTitleInfo> ParseUniversalCorrectionDocumentBuyerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseUniversalCorrectionDocumentBuyerTitleXmlAsync(authToken, xmlContent);
 		}
 
 		public Task<byte[]> ParseTitleXmlAsync(
@@ -952,6 +1078,13 @@ namespace Diadoc.Api
 			return diadocHttpApi.GetOrganizationsByInnListAsync(innList);
 		}
 
+		public Task<List<Organization>> GetOrganizationsByInnListAsync(string authToken, GetOrganizationsByInnListRequest innList)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			if (innList == null) throw new ArgumentNullException(nameof(innList));
+			return diadocHttpApi.GetOrganizationsByInnListAsync(authToken, innList);
+		}
+
 		public Task<List<OrganizationWithCounteragentStatus>> GetOrganizationsByInnListAsync(string authToken, string myOrgId,
 			GetOrganizationsByInnListRequest innList)
 		{
@@ -969,9 +1102,21 @@ namespace Diadoc.Api
 			return diadocHttpApi.ParseRevocationRequestXmlAsync(revocationRequestXmlContent);
 		}
 
+		public Task<RevocationRequestInfo> ParseRevocationRequestXmlAsync(string authToken, byte[] revocationRequestXmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseRevocationRequestXmlAsync(authToken, revocationRequestXmlContent);
+		}
+
 		public Task<SignatureRejectionInfo> ParseSignatureRejectionXmlAsync(byte[] signatureRejectionXmlContent)
 		{
 			return diadocHttpApi.ParseSignatureRejectionXmlAsync(signatureRejectionXmlContent);
+		}
+
+		public Task<SignatureRejectionInfo> ParseSignatureRejectionXmlAsync(string authToken, byte[] signatureRejectionXmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseSignatureRejectionXmlAsync(authToken, signatureRejectionXmlContent);
 		}
 
 		public Task<DocumentProtocolResult> GenerateDocumentProtocolAsync(string authToken, string boxId, string messageId,

--- a/src/DiadocApi.cs
+++ b/src/DiadocApi.cs
@@ -208,10 +208,24 @@ namespace Diadoc.Api
 			return diadocHttpApi.GetOrganizationsByInnKpp(inn, kpp, includeRelations);
 		}
 
+		public OrganizationList GetOrganizationsByInnKpp(string authToken, string inn, string kpp, bool includeRelations = false)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			if (inn == null) throw new ArgumentNullException(nameof(inn));
+			return diadocHttpApi.GetOrganizationsByInnKpp(authToken, inn, kpp, includeRelations);
+		}
+
 		public Organization GetOrganizationById(string orgId)
 		{
 			if (orgId == null) throw new ArgumentNullException("orgId");
 			return diadocHttpApi.GetOrganizationById(orgId);
+		}
+
+		public Organization GetOrganizationById(string authToken, string orgId)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			if (orgId == null) throw new ArgumentNullException(nameof(orgId));
+			return diadocHttpApi.GetOrganizationById(authToken, orgId);
 		}
 
 		public Organization GetOrganizationByBoxId(string boxId)
@@ -220,16 +234,37 @@ namespace Diadoc.Api
 			return diadocHttpApi.GetOrganizationByBoxId(boxId);
 		}
 
+		public Organization GetOrganizationByBoxId(string authToken, string boxId)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			if (boxId == null) throw new ArgumentNullException(nameof(boxId));
+			return diadocHttpApi.GetOrganizationByBoxId(authToken, boxId);
+		}
+
 		public Organization GetOrganizationByFnsParticipantId(string fnsParticipantId)
 		{
 			if (fnsParticipantId == null) throw new ArgumentException("fnsParticipantId");
 			return diadocHttpApi.GetOrganizationByFnsParticipantId(fnsParticipantId);
 		}
 
+		public Organization GetOrganizationByFnsParticipantId(string authToken, string fnsParticipantId)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			if (fnsParticipantId == null) throw new ArgumentNullException(nameof(fnsParticipantId));
+			return diadocHttpApi.GetOrganizationByFnsParticipantId(authToken, fnsParticipantId);
+		}
+
 		public Organization GetOrganizationByInnKpp(string inn, string kpp)
 		{
 			if (inn == null) throw new ArgumentException("inn");
 			return diadocHttpApi.GetOrganizationByInnKpp(inn, kpp);
+		}
+
+		public Organization GetOrganizationByInnKpp(string authToken, string inn, string kpp)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			if (inn == null) throw new ArgumentNullException(nameof(inn));
+			return diadocHttpApi.GetOrganizationByInnKpp(authToken, inn, kpp);
 		}
 
 		public RoamingOperatorList GetRoamingOperators(string authToken, string boxId)
@@ -241,6 +276,13 @@ namespace Diadoc.Api
 		{
 			if (boxId == null) throw new ArgumentNullException("boxId");
 			return diadocHttpApi.GetBox(boxId);
+		}
+
+		public Box GetBox(string authToken, string boxId)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			if (boxId == null) throw new ArgumentNullException(nameof(boxId));
+			return diadocHttpApi.GetBox(authToken, boxId);
 		}
 
 		public Department GetDepartment(string authToken, string orgId, string departmentId)
@@ -975,9 +1017,21 @@ namespace Diadoc.Api
 			return diadocHttpApi.ParseRussianAddress(address);
 		}
 
+		public RussianAddress ParseRussianAddress(string authToken, string address)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseRussianAddress(authToken, address);
+		}
+
 		public InvoiceInfo ParseInvoiceXml(byte[] invoiceXmlContent)
 		{
 			return diadocHttpApi.ParseInvoiceXml(invoiceXmlContent);
+		}
+
+		public InvoiceInfo ParseInvoiceXml(string authToken, byte[] invoiceXmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseInvoiceXml(authToken, invoiceXmlContent);
 		}
 
 		public Torg12SellerTitleInfo ParseTorg12SellerTitleXml(byte[] xmlContent)
@@ -985,9 +1039,21 @@ namespace Diadoc.Api
 			return diadocHttpApi.ParseTorg12SellerTitleXml(xmlContent);
 		}
 
+		public Torg12SellerTitleInfo ParseTorg12SellerTitleXml(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseTorg12SellerTitleXml(authToken, xmlContent);
+		}
+
 		public Torg12BuyerTitleInfo ParseTorg12BuyerTitleXml(byte[] xmlContent)
 		{
 			return diadocHttpApi.ParseTorg12BuyerTitleXml(xmlContent);
+		}
+
+		public Torg12BuyerTitleInfo ParseTorg12BuyerTitleXml(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseTorg12BuyerTitleXml(authToken, xmlContent);
 		}
 
 		public TovTorgSellerTitleInfo ParseTovTorg551SellerTitleXml(byte[] xmlContent)
@@ -995,9 +1061,21 @@ namespace Diadoc.Api
 			return diadocHttpApi.ParseTovTorg551SellerTitleXml(xmlContent);
 		}
 
+		public TovTorgSellerTitleInfo ParseTovTorg551SellerTitleXml(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseTovTorg551SellerTitleXml(authToken, xmlContent);
+		}
+
 		public TovTorgBuyerTitleInfo ParseTovTorg551BuyerTitleXml(byte[] xmlContent)
 		{
 			return diadocHttpApi.ParseTovTorg551BuyerTitleXml(xmlContent);
+		}
+
+		public TovTorgBuyerTitleInfo ParseTovTorg551BuyerTitleXml(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseTovTorg551BuyerTitleXml(authToken, xmlContent);
 		}
 
 		public AcceptanceCertificateSellerTitleInfo ParseAcceptanceCertificateSellerTitleXml(byte[] xmlContent)
@@ -1005,9 +1083,21 @@ namespace Diadoc.Api
 			return diadocHttpApi.ParseAcceptanceCertificateSellerTitleXml(xmlContent);
 		}
 
+		public AcceptanceCertificateSellerTitleInfo ParseAcceptanceCertificateSellerTitleXml(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseAcceptanceCertificateSellerTitleXml(authToken, xmlContent);
+		}
+
 		public AcceptanceCertificateBuyerTitleInfo ParseAcceptanceCertificateBuyerTitleXml(byte[] xmlContent)
 		{
 			return diadocHttpApi.ParseAcceptanceCertificateBuyerTitleXml(xmlContent);
+		}
+
+		public AcceptanceCertificateBuyerTitleInfo ParseAcceptanceCertificateBuyerTitleXml(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseAcceptanceCertificateBuyerTitleXml(authToken, xmlContent);
 		}
 
 		public AcceptanceCertificate552SellerTitleInfo ParseAcceptanceCertificate552SellerTitleXml(byte[] xmlContent)
@@ -1015,9 +1105,21 @@ namespace Diadoc.Api
 			return diadocHttpApi.ParseAcceptanceCertificate552SellerTitleXml(xmlContent);
 		}
 
+		public AcceptanceCertificate552SellerTitleInfo ParseAcceptanceCertificate552SellerTitleXml(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseAcceptanceCertificate552SellerTitleXml(authToken, xmlContent);
+		}
+
 		public AcceptanceCertificate552BuyerTitleInfo ParseAcceptanceCertificate552BuyerTitleXml(byte[] xmlContent)
 		{
 			return diadocHttpApi.ParseAcceptanceCertificate552BuyerTitleXml(xmlContent);
+		}
+
+		public AcceptanceCertificate552BuyerTitleInfo ParseAcceptanceCertificate552BuyerTitleXml(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseAcceptanceCertificate552BuyerTitleXml(authToken, xmlContent);
 		}
 
 		public UniversalTransferDocumentSellerTitleInfo ParseUniversalTransferDocumentSellerTitleXml(byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Utd)
@@ -1025,9 +1127,21 @@ namespace Diadoc.Api
 			return diadocHttpApi.ParseUniversalTransferDocumentSellerTitleXml(xmlContent, documentVersion);
 		}
 
+		public UniversalTransferDocumentSellerTitleInfo ParseUniversalTransferDocumentSellerTitleXml(string authToken, byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Utd)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseUniversalTransferDocumentSellerTitleXml(authToken, xmlContent, documentVersion);
+		}
+
 		public UniversalTransferDocumentBuyerTitleInfo ParseUniversalTransferDocumentBuyerTitleXml(byte[] xmlContent)
 		{
 			return diadocHttpApi.ParseUniversalTransferDocumentBuyerTitleXml(xmlContent);
+		}
+
+		public UniversalTransferDocumentBuyerTitleInfo ParseUniversalTransferDocumentBuyerTitleXml(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseUniversalTransferDocumentBuyerTitleXml(authToken, xmlContent);
 		}
 
 		public UniversalCorrectionDocumentSellerTitleInfo ParseUniversalCorrectionDocumentSellerTitleXml(byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Ucd)
@@ -1035,9 +1149,21 @@ namespace Diadoc.Api
 			return diadocHttpApi.ParseUniversalCorrectionDocumentSellerTitleXml(xmlContent, documentVersion);
 		}
 
+		public UniversalCorrectionDocumentSellerTitleInfo ParseUniversalCorrectionDocumentSellerTitleXml(string authToken, byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Ucd)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseUniversalCorrectionDocumentSellerTitleXml(authToken, xmlContent, documentVersion);
+		}
+
 		public UniversalTransferDocumentBuyerTitleInfo ParseUniversalCorrectionDocumentBuyerTitleXml(byte[] xmlContent)
 		{
 			return diadocHttpApi.ParseUniversalCorrectionDocumentBuyerTitleXml(xmlContent);
+		}
+
+		public UniversalTransferDocumentBuyerTitleInfo ParseUniversalCorrectionDocumentBuyerTitleXml(string authToken, byte[] xmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseUniversalCorrectionDocumentBuyerTitleXml(authToken, xmlContent);
 		}
 
 		public byte[] ParseTitleXml(
@@ -1088,6 +1214,13 @@ namespace Diadoc.Api
 			return diadocHttpApi.GetOrganizationsByInnList(innList);
 		}
 
+		public List<Organization> GetOrganizationsByInnList(string authToken, GetOrganizationsByInnListRequest innList)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			if (innList == null) throw new ArgumentNullException(nameof(innList));
+			return diadocHttpApi.GetOrganizationsByInnList(authToken, innList);
+		}
+
 		public List<OrganizationWithCounteragentStatus> GetOrganizationsByInnList(string authToken,
 			string myOrgId,
 			GetOrganizationsByInnListRequest innList)
@@ -1106,9 +1239,21 @@ namespace Diadoc.Api
 			return diadocHttpApi.ParseRevocationRequestXml(revocationRequestXmlContent);
 		}
 
+		public RevocationRequestInfo ParseRevocationRequestXml(string authToken, byte[] revocationRequestXmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseRevocationRequestXml(authToken, revocationRequestXmlContent);
+		}
+
 		public SignatureRejectionInfo ParseSignatureRejectionXml(byte[] signatureRejectionXmlContent)
 		{
 			return diadocHttpApi.ParseSignatureRejectionXml(signatureRejectionXmlContent);
+		}
+
+		public SignatureRejectionInfo ParseSignatureRejectionXml(string authToken, byte[] signatureRejectionXmlContent)
+		{
+			if (authToken == null) throw new ArgumentNullException(nameof(authToken));
+			return diadocHttpApi.ParseSignatureRejectionXml(authToken, signatureRejectionXmlContent);
 		}
 
 		public DocumentProtocolResult GenerateDocumentProtocol(string authToken,

--- a/src/DiadocApi.cs
+++ b/src/DiadocApi.cs
@@ -99,6 +99,14 @@ namespace Diadoc.Api
 			diadocHttpApi.SolutionInfo = solutionInfo;
 		}
 
+		/// <summary>
+		/// Использовать аутентификацию по протоколу OpenID Connect
+		/// </summary>
+		public void UseOidc()
+		{
+			diadocHttpApi.UseOidc = true;
+		}
+
 		public string Authenticate(string login, string password, string key = null, string id = null)
 		{
 			return diadocHttpApi.Authenticate(login, password, key, id);

--- a/src/DiadocHttpApi.Invoicing.cs
+++ b/src/DiadocHttpApi.Invoicing.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
+using Diadoc.Api.Constants;
 using Diadoc.Api.Http;
 using Diadoc.Api.Proto.Events;
 using Diadoc.Api.Proto.Invoicing;
@@ -248,14 +249,26 @@ namespace Diadoc.Api
 			HttpClient.PerformHttpRequest(request);
 		}
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public RevocationRequestInfo ParseRevocationRequestXml(byte[] xmlContent)
 		{
-			return PerformHttpRequest<RevocationRequestInfo>(null, "POST", "/ParseRevocationRequestXml", xmlContent);
+			return ParseRevocationRequestXml(null, xmlContent);
 		}
 
+		public RevocationRequestInfo ParseRevocationRequestXml(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequest<RevocationRequestInfo>(authToken, "POST", "/ParseRevocationRequestXml", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public SignatureRejectionInfo ParseSignatureRejectionXml(byte[] xmlContent)
 		{
-			return PerformHttpRequest<SignatureRejectionInfo>(null, "POST", "/ParseSignatureRejectionXml", xmlContent);
+			return ParseSignatureRejectionXml(null, xmlContent);
+		}
+
+		public SignatureRejectionInfo ParseSignatureRejectionXml(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequest<SignatureRejectionInfo>(authToken, "POST", "/ParseSignatureRejectionXml", xmlContent);
 		}
 
 		[Obsolete("Use overload with DocumentTitleType parameter")]

--- a/src/DiadocHttpApi.InvoicingAsync.cs
+++ b/src/DiadocHttpApi.InvoicingAsync.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using Diadoc.Api.Constants;
 using Diadoc.Api.Http;
 using Diadoc.Api.Proto.Events;
 using Diadoc.Api.Proto.Invoicing;
@@ -261,14 +262,26 @@ namespace Diadoc.Api
 			return HttpClient.PerformHttpRequestAsync(request);
 		}
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<RevocationRequestInfo> ParseRevocationRequestXmlAsync(byte[] xmlContent)
 		{
-			return PerformHttpRequestAsync<RevocationRequestInfo>(null, "POST", "/ParseRevocationRequestXml", xmlContent);
+			return ParseRevocationRequestXmlAsync(null, xmlContent);
 		}
 
+		public Task<RevocationRequestInfo> ParseRevocationRequestXmlAsync(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequestAsync<RevocationRequestInfo>(authToken, "POST", "/ParseRevocationRequestXml", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<SignatureRejectionInfo> ParseSignatureRejectionXmlAsync(byte[] xmlContent)
 		{
-			return PerformHttpRequestAsync<SignatureRejectionInfo>(null, "POST", "/ParseSignatureRejectionXml", xmlContent);
+			return ParseSignatureRejectionXmlAsync(null, xmlContent);
+		}
+
+		public Task<SignatureRejectionInfo> ParseSignatureRejectionXmlAsync(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequestAsync<SignatureRejectionInfo>(authToken, "POST", "/ParseSignatureRejectionXml", xmlContent);
 		}
 
 		[Obsolete("Use overload with DocumentTitleType parameter")]

--- a/src/DiadocHttpApi.Parse.cs
+++ b/src/DiadocHttpApi.Parse.cs
@@ -1,3 +1,5 @@
+using System;
+using Diadoc.Api.Constants;
 using Diadoc.Api.Http;
 using Diadoc.Api.Proto.Invoicing;
 
@@ -5,73 +7,151 @@ namespace Diadoc.Api
 {
 	public partial class DiadocHttpApi
 	{
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public InvoiceInfo ParseInvoiceXml(byte[] invoiceXmlContent)
 		{
-			return PerformHttpRequest<InvoiceInfo>(null, "POST", "/ParseInvoiceXml", invoiceXmlContent);
+			return ParseInvoiceXml(null, invoiceXmlContent);
 		}
 
+		public InvoiceInfo ParseInvoiceXml(string authToken, byte[] invoiceXmlContent)
+		{
+			return PerformHttpRequest<InvoiceInfo>(authToken, "POST", "/ParseInvoiceXml", invoiceXmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Torg12SellerTitleInfo ParseTorg12SellerTitleXml(byte[] xmlContent)
 		{
-			return PerformHttpRequest<Torg12SellerTitleInfo>(null, "POST", "/ParseTorg12SellerTitleXml", xmlContent);
+			return ParseTorg12SellerTitleXml(null, xmlContent);
 		}
 
+		public Torg12SellerTitleInfo ParseTorg12SellerTitleXml(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequest<Torg12SellerTitleInfo>(authToken, "POST", "/ParseTorg12SellerTitleXml", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Torg12BuyerTitleInfo ParseTorg12BuyerTitleXml(byte[] xmlContent)
 		{
-			return PerformHttpRequest<Torg12BuyerTitleInfo>(null, "POST", "/ParseTorg12BuyerTitleXml", xmlContent);
+			return ParseTorg12BuyerTitleXml(null, xmlContent);
 		}
 
+		public Torg12BuyerTitleInfo ParseTorg12BuyerTitleXml(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequest<Torg12BuyerTitleInfo>(authToken, "POST", "/ParseTorg12BuyerTitleXml", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public TovTorgSellerTitleInfo ParseTovTorg551SellerTitleXml(byte[] xmlContent)
 		{
-			return PerformHttpRequest<TovTorgSellerTitleInfo>(null, "POST", $"/ParseTorg12SellerTitleXml?documentVersion={DefaultDocumentVersions.TovTorg551}", xmlContent);
+			return ParseTovTorg551SellerTitleXml(null, xmlContent);
 		}
 
+		public TovTorgSellerTitleInfo ParseTovTorg551SellerTitleXml(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequest<TovTorgSellerTitleInfo>(authToken, "POST", $"/ParseTorg12SellerTitleXml?documentVersion={DefaultDocumentVersions.TovTorg551}", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public TovTorgBuyerTitleInfo ParseTovTorg551BuyerTitleXml(byte[] xmlContent)
 		{
-			return PerformHttpRequest<TovTorgBuyerTitleInfo>(null, "POST", $"/ParseTorg12BuyerTitleXml?documentVersion={DefaultDocumentVersions.TovTorg551}", xmlContent);
+			return ParseTovTorg551BuyerTitleXml(null, xmlContent);
 		}
 
+		public TovTorgBuyerTitleInfo ParseTovTorg551BuyerTitleXml(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequest<TovTorgBuyerTitleInfo>(authToken, "POST", $"/ParseTorg12BuyerTitleXml?documentVersion={DefaultDocumentVersions.TovTorg551}", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public AcceptanceCertificateSellerTitleInfo ParseAcceptanceCertificateSellerTitleXml(byte[] xmlContent)
 		{
-			return PerformHttpRequest<AcceptanceCertificateSellerTitleInfo>(null, "POST", "/ParseAcceptanceCertificateSellerTitleXml", xmlContent);
+			return ParseAcceptanceCertificateSellerTitleXml(null, xmlContent);
 		}
 
+		public AcceptanceCertificateSellerTitleInfo ParseAcceptanceCertificateSellerTitleXml(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequest<AcceptanceCertificateSellerTitleInfo>(authToken, "POST", "/ParseAcceptanceCertificateSellerTitleXml", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public AcceptanceCertificateBuyerTitleInfo ParseAcceptanceCertificateBuyerTitleXml(byte[] xmlContent)
 		{
-			return PerformHttpRequest<AcceptanceCertificateBuyerTitleInfo>(null, "POST", "/ParseAcceptanceCertificateBuyerTitleXml", xmlContent);
+			return ParseAcceptanceCertificateBuyerTitleXml(null, xmlContent);
 		}
 
+		public AcceptanceCertificateBuyerTitleInfo ParseAcceptanceCertificateBuyerTitleXml(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequest<AcceptanceCertificateBuyerTitleInfo>(authToken, "POST", "/ParseAcceptanceCertificateBuyerTitleXml", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public AcceptanceCertificate552SellerTitleInfo ParseAcceptanceCertificate552SellerTitleXml(byte[] xmlContent)
 		{
-			return PerformHttpRequest<AcceptanceCertificate552SellerTitleInfo>(null, "POST", $"/ParseAcceptanceCertificateSellerTitleXml?documentVersion={DefaultDocumentVersions.AcceptanceCerttificate552}", xmlContent);
+			return ParseAcceptanceCertificate552SellerTitleXml(null, xmlContent);
 		}
 
+		public AcceptanceCertificate552SellerTitleInfo ParseAcceptanceCertificate552SellerTitleXml(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequest<AcceptanceCertificate552SellerTitleInfo>(authToken, "POST", $"/ParseAcceptanceCertificateSellerTitleXml?documentVersion={DefaultDocumentVersions.AcceptanceCerttificate552}", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public AcceptanceCertificate552BuyerTitleInfo ParseAcceptanceCertificate552BuyerTitleXml(byte[] xmlContent)
 		{
-			return PerformHttpRequest<AcceptanceCertificate552BuyerTitleInfo>(null, "POST", $"/ParseAcceptanceCertificateBuyerTitleXml?documentVersion={DefaultDocumentVersions.AcceptanceCerttificate552}", xmlContent);
+			return ParseAcceptanceCertificate552BuyerTitleXml(null, xmlContent);
 		}
 
+		public AcceptanceCertificate552BuyerTitleInfo ParseAcceptanceCertificate552BuyerTitleXml(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequest<AcceptanceCertificate552BuyerTitleInfo>(authToken, "POST", $"/ParseAcceptanceCertificateBuyerTitleXml?documentVersion={DefaultDocumentVersions.AcceptanceCerttificate552}", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public UniversalTransferDocumentSellerTitleInfo ParseUniversalTransferDocumentSellerTitleXml(byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Utd)
+		{
+			return ParseUniversalTransferDocumentSellerTitleXml(null, xmlContent, documentVersion);
+		}
+
+		public UniversalTransferDocumentSellerTitleInfo ParseUniversalTransferDocumentSellerTitleXml(string authToken, byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Utd)
 		{
 			var query = new PathAndQueryBuilder("/ParseUniversalTransferDocumentSellerTitleXml");
 			query.AddParameter("documentVersion", documentVersion);
-			return PerformHttpRequest<UniversalTransferDocumentSellerTitleInfo>(null, "POST", query.BuildPathAndQuery(), xmlContent);
+			return PerformHttpRequest<UniversalTransferDocumentSellerTitleInfo>(authToken, "POST", query.BuildPathAndQuery(), xmlContent);
 		}
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public UniversalTransferDocumentBuyerTitleInfo ParseUniversalTransferDocumentBuyerTitleXml(byte[] xmlContent)
 		{
-			return PerformHttpRequest<UniversalTransferDocumentBuyerTitleInfo>(null, "POST", "/ParseUniversalTransferDocumentBuyerTitleXml", xmlContent);
+			return ParseUniversalTransferDocumentBuyerTitleXml(null, xmlContent);
 		}
 
+		public UniversalTransferDocumentBuyerTitleInfo ParseUniversalTransferDocumentBuyerTitleXml(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequest<UniversalTransferDocumentBuyerTitleInfo>(authToken, "POST", "/ParseUniversalTransferDocumentBuyerTitleXml", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public UniversalCorrectionDocumentSellerTitleInfo ParseUniversalCorrectionDocumentSellerTitleXml(byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Ucd)
+		{
+			return ParseUniversalCorrectionDocumentSellerTitleXml(null, xmlContent, documentVersion);
+		}
+
+		public UniversalCorrectionDocumentSellerTitleInfo ParseUniversalCorrectionDocumentSellerTitleXml(string authToken, byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Ucd)
 		{
 			var query = new PathAndQueryBuilder("/ParseUniversalCorrectionDocumentSellerTitleXml");
 			query.AddParameter("documentVersion", documentVersion);
-			return PerformHttpRequest<UniversalCorrectionDocumentSellerTitleInfo>(null, "POST", query.BuildPathAndQuery(), xmlContent);
+			return PerformHttpRequest<UniversalCorrectionDocumentSellerTitleInfo>(authToken, "POST", query.BuildPathAndQuery(), xmlContent);
 		}
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public UniversalTransferDocumentBuyerTitleInfo ParseUniversalCorrectionDocumentBuyerTitleXml(byte[] xmlContent)
 		{
-			return PerformHttpRequest<UniversalTransferDocumentBuyerTitleInfo>(null, "POST", "/ParseUniversalCorrectionDocumentBuyerTitleXml", xmlContent);
+			return ParseUniversalCorrectionDocumentBuyerTitleXml(null, xmlContent);
+		}
+
+		public UniversalTransferDocumentBuyerTitleInfo ParseUniversalCorrectionDocumentBuyerTitleXml(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequest<UniversalTransferDocumentBuyerTitleInfo>(authToken, "POST", "/ParseUniversalCorrectionDocumentBuyerTitleXml", xmlContent);
 		}
 
 		public byte[] ParseTitleXml(

--- a/src/DiadocHttpApi.ParseAsync.cs
+++ b/src/DiadocHttpApi.ParseAsync.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Threading.Tasks;
+using Diadoc.Api.Constants;
 using Diadoc.Api.Http;
 using Diadoc.Api.Proto.Invoicing;
 
@@ -6,73 +8,151 @@ namespace Diadoc.Api
 {
 	public partial class DiadocHttpApi
 	{
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<InvoiceInfo> ParseInvoiceXmlAsync(byte[] invoiceXmlContent)
 		{
-			return PerformHttpRequestAsync<InvoiceInfo>(null, "POST", "/ParseInvoiceXml", invoiceXmlContent);
+			return ParseInvoiceXmlAsync(null, invoiceXmlContent);
 		}
 
+		public Task<InvoiceInfo> ParseInvoiceXmlAsync(string authToken, byte[] invoiceXmlContent)
+		{
+			return PerformHttpRequestAsync<InvoiceInfo>(authToken, "POST", "/ParseInvoiceXml", invoiceXmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<Torg12SellerTitleInfo> ParseTorg12SellerTitleXmlAsync(byte[] xmlContent)
 		{
-			return PerformHttpRequestAsync<Torg12SellerTitleInfo>(null, "POST", "/ParseTorg12SellerTitleXml", xmlContent);
+			return ParseTorg12SellerTitleXmlAsync(null, xmlContent);
 		}
 
+		public Task<Torg12SellerTitleInfo> ParseTorg12SellerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequestAsync<Torg12SellerTitleInfo>(authToken, "POST", "/ParseTorg12SellerTitleXml", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<Torg12BuyerTitleInfo> ParseTorg12BuyerTitleXmlAsync(byte[] xmlContent)
 		{
-			return PerformHttpRequestAsync<Torg12BuyerTitleInfo>(null, "POST", "/ParseTorg12BuyerTitleXml", xmlContent);
+			return ParseTorg12BuyerTitleXmlAsync(null, xmlContent);
 		}
 
+		public Task<Torg12BuyerTitleInfo> ParseTorg12BuyerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequestAsync<Torg12BuyerTitleInfo>(authToken, "POST", "/ParseTorg12BuyerTitleXml", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<TovTorgSellerTitleInfo> ParseTovTorg551SellerTitleXmlAsync(byte[] xmlContent)
 		{
-			return PerformHttpRequestAsync<TovTorgSellerTitleInfo>(null, "POST", $"/ParseTorg12SellerTitleXml?documentVersion={DefaultDocumentVersions.TovTorg551}", xmlContent);
+			return ParseTovTorg551SellerTitleXmlAsync(null, xmlContent);
 		}
 
+		public Task<TovTorgSellerTitleInfo> ParseTovTorg551SellerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequestAsync<TovTorgSellerTitleInfo>(authToken, "POST", $"/ParseTorg12SellerTitleXml?documentVersion={DefaultDocumentVersions.TovTorg551}", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<TovTorgBuyerTitleInfo> ParseTovTorg551BuyerTitleXmlAsync(byte[] xmlContent)
 		{
-			return PerformHttpRequestAsync<TovTorgBuyerTitleInfo>(null, "POST", $"/ParseTorg12BuyerTitleXml?documentVersion={DefaultDocumentVersions.TovTorg551}", xmlContent);
+			return ParseTovTorg551BuyerTitleXmlAsync(null, xmlContent);
 		}
 
+		public Task<TovTorgBuyerTitleInfo> ParseTovTorg551BuyerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequestAsync<TovTorgBuyerTitleInfo>(authToken, "POST", $"/ParseTorg12BuyerTitleXml?documentVersion={DefaultDocumentVersions.TovTorg551}", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<AcceptanceCertificateSellerTitleInfo> ParseAcceptanceCertificateSellerTitleXmlAsync(byte[] xmlContent)
 		{
-			return PerformHttpRequestAsync<AcceptanceCertificateSellerTitleInfo>(null, "POST", "/ParseAcceptanceCertificateSellerTitleXml", xmlContent);
+			return ParseAcceptanceCertificateSellerTitleXmlAsync(null, xmlContent);
 		}
 
+		public Task<AcceptanceCertificateSellerTitleInfo> ParseAcceptanceCertificateSellerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequestAsync<AcceptanceCertificateSellerTitleInfo>(authToken, "POST", "/ParseAcceptanceCertificateSellerTitleXml", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<AcceptanceCertificateBuyerTitleInfo> ParseAcceptanceCertificateBuyerTitleXmlAsync(byte[] xmlContent)
 		{
-			return PerformHttpRequestAsync<AcceptanceCertificateBuyerTitleInfo>(null, "POST", "/ParseAcceptanceCertificateBuyerTitleXml", xmlContent);
+			return ParseAcceptanceCertificateBuyerTitleXmlAsync(null, xmlContent);
 		}
 
+		public Task<AcceptanceCertificateBuyerTitleInfo> ParseAcceptanceCertificateBuyerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequestAsync<AcceptanceCertificateBuyerTitleInfo>(authToken, "POST", "/ParseAcceptanceCertificateBuyerTitleXml", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<AcceptanceCertificate552SellerTitleInfo> ParseAcceptanceCertificate552SellerTitleXmlAsync(byte[] xmlContent)
 		{
-			return PerformHttpRequestAsync<AcceptanceCertificate552SellerTitleInfo>(null, "POST", $"/ParseAcceptanceCertificateSellerTitleXml?documentVersion={DefaultDocumentVersions.AcceptanceCerttificate552}", xmlContent);
+			return ParseAcceptanceCertificate552SellerTitleXmlAsync(null, xmlContent);
 		}
 
+		public Task<AcceptanceCertificate552SellerTitleInfo> ParseAcceptanceCertificate552SellerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequestAsync<AcceptanceCertificate552SellerTitleInfo>(authToken, "POST", $"/ParseAcceptanceCertificateSellerTitleXml?documentVersion={DefaultDocumentVersions.AcceptanceCerttificate552}", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<AcceptanceCertificate552BuyerTitleInfo> ParseAcceptanceCertificate552BuyerTitleXmlAsync(byte[] xmlContent)
 		{
-			return PerformHttpRequestAsync<AcceptanceCertificate552BuyerTitleInfo>(null, "POST", $"/ParseAcceptanceCertificateBuyerTitleXml?documentVersion={DefaultDocumentVersions.AcceptanceCerttificate552}", xmlContent);
+			return ParseAcceptanceCertificate552BuyerTitleXmlAsync(null, xmlContent);
 		}
 
+		public Task<AcceptanceCertificate552BuyerTitleInfo> ParseAcceptanceCertificate552BuyerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequestAsync<AcceptanceCertificate552BuyerTitleInfo>(authToken, "POST", $"/ParseAcceptanceCertificateBuyerTitleXml?documentVersion={DefaultDocumentVersions.AcceptanceCerttificate552}", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<UniversalTransferDocumentSellerTitleInfo> ParseUniversalTransferDocumentSellerTitleXmlAsync(byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Utd)
+		{
+			return ParseUniversalTransferDocumentSellerTitleXmlAsync(null, xmlContent, documentVersion);
+		}
+
+		public Task<UniversalTransferDocumentSellerTitleInfo> ParseUniversalTransferDocumentSellerTitleXmlAsync(string authToken, byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Utd)
 		{
 			var query = new PathAndQueryBuilder("/ParseUniversalTransferDocumentSellerTitleXml");
 			query.AddParameter("documentVersion", documentVersion);
-			return PerformHttpRequestAsync<UniversalTransferDocumentSellerTitleInfo>(null, "POST", query.BuildPathAndQuery(), xmlContent);
+			return PerformHttpRequestAsync<UniversalTransferDocumentSellerTitleInfo>(authToken, "POST", query.BuildPathAndQuery(), xmlContent);
 		}
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<UniversalTransferDocumentBuyerTitleInfo> ParseUniversalTransferDocumentBuyerTitleXmlAsync(byte[] xmlContent)
 		{
-			return PerformHttpRequestAsync<UniversalTransferDocumentBuyerTitleInfo>(null, "POST", "/ParseUniversalTransferDocumentBuyerTitleXml", xmlContent);
+			return ParseUniversalTransferDocumentBuyerTitleXmlAsync(null, xmlContent);
 		}
 
+		public Task<UniversalTransferDocumentBuyerTitleInfo> ParseUniversalTransferDocumentBuyerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequestAsync<UniversalTransferDocumentBuyerTitleInfo>(authToken, "POST", "/ParseUniversalTransferDocumentBuyerTitleXml", xmlContent);
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<UniversalCorrectionDocumentSellerTitleInfo> ParseUniversalCorrectionDocumentSellerTitleXmlAsync(byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Ucd)
+		{
+			return ParseUniversalCorrectionDocumentSellerTitleXmlAsync(null, xmlContent, documentVersion);
+		}
+
+		public Task<UniversalCorrectionDocumentSellerTitleInfo> ParseUniversalCorrectionDocumentSellerTitleXmlAsync(string authToken, byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Ucd)
 		{
 			var query = new PathAndQueryBuilder("/ParseUniversalCorrectionDocumentSellerTitleXml");
 			query.AddParameter("documentVersion", documentVersion);
-			return PerformHttpRequestAsync<UniversalCorrectionDocumentSellerTitleInfo>(null, "POST", query.BuildPathAndQuery(), xmlContent);
+			return PerformHttpRequestAsync<UniversalCorrectionDocumentSellerTitleInfo>(authToken, "POST", query.BuildPathAndQuery(), xmlContent);
 		}
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<UniversalTransferDocumentBuyerTitleInfo> ParseUniversalCorrectionDocumentBuyerTitleXmlAsync(byte[] xmlContent)
 		{
-			return PerformHttpRequestAsync<UniversalTransferDocumentBuyerTitleInfo>(null, "POST", "/ParseUniversalCorrectionDocumentBuyerTitleXml", xmlContent);
+			return ParseUniversalCorrectionDocumentBuyerTitleXmlAsync(null, xmlContent);
+		}
+
+		public Task<UniversalTransferDocumentBuyerTitleInfo> ParseUniversalCorrectionDocumentBuyerTitleXmlAsync(string authToken, byte[] xmlContent)
+		{
+			return PerformHttpRequestAsync<UniversalTransferDocumentBuyerTitleInfo>(authToken, "POST", "/ParseUniversalCorrectionDocumentBuyerTitleXml", xmlContent);
 		}
 
 		public Task<byte[]> ParseTitleXmlAsync(

--- a/src/DiadocHttpApi.Recognize.cs
+++ b/src/DiadocHttpApi.Recognize.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
+using Diadoc.Api.Constants;
 using Diadoc.Api.Proto;
 using Diadoc.Api.Proto.Recognition;
 
@@ -19,10 +21,16 @@ namespace Diadoc.Api
 			return PerformHttpRequest<Recognized>(null, "GET", queryString);
 		}
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public RussianAddress ParseRussianAddress(string address)
 		{
+			return ParseRussianAddress(null, address);
+		}
+
+		public RussianAddress ParseRussianAddress(string authToken, string address)
+		{
 			var queryString = string.Format("/ParseRussianAddress?address={0}", address);
-			return PerformHttpRequest<RussianAddress>(null, "GET", queryString);
+			return PerformHttpRequest<RussianAddress>(authToken, "GET", queryString);
 		}
 	}
 }

--- a/src/DiadocHttpApi.RecognizeAsync.cs
+++ b/src/DiadocHttpApi.RecognizeAsync.cs
@@ -1,5 +1,7 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using System.Threading.Tasks;
+using Diadoc.Api.Constants;
 using Diadoc.Api.Proto;
 using Diadoc.Api.Proto.Recognition;
 
@@ -20,10 +22,16 @@ namespace Diadoc.Api
 			return PerformHttpRequestAsync<Recognized>(null, "GET", queryString);
 		}
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<RussianAddress> ParseRussianAddressAsync(string address)
 		{
+			return ParseRussianAddressAsync(null, address);
+		}
+
+		public Task<RussianAddress> ParseRussianAddressAsync(string authToken, string address)
+		{
 			var queryString = $"/ParseRussianAddress?address={address}";
-			return PerformHttpRequestAsync<RussianAddress>(null, "GET", queryString);
+			return PerformHttpRequestAsync<RussianAddress>(authToken, "GET", queryString);
 		}
 	}
 }

--- a/src/DiadocHttpApi.References.cs
+++ b/src/DiadocHttpApi.References.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Diadoc.Api.Constants;
 using Diadoc.Api.Http;
 using Diadoc.Api.Proto;
 using Diadoc.Api.Proto.Certificates;
@@ -47,50 +48,86 @@ namespace Diadoc.Api
 			return PerformHttpRequest<CertificateList>(authToken, "GET", queryBuilder.BuildPathAndQuery());
 		}
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public OrganizationList GetOrganizationsByInnKpp(string inn, string kpp, bool includeRelations = false)
+		{
+			return GetOrganizationsByInnKpp(null, inn, kpp, includeRelations);
+		}
+
+		public OrganizationList GetOrganizationsByInnKpp(string authToken, string inn, string kpp, bool includeRelations = false)
 		{
 			var qsb = new PathAndQueryBuilder("/GetOrganizationsByInnKpp");
 			qsb.AddParameter("inn", inn);
 			if (!string.IsNullOrEmpty(kpp)) qsb.AddParameter("kpp", kpp);
 			if (includeRelations)
 				qsb.AddParameter("includeRelations", "true");
-			return PerformHttpRequest<OrganizationList>(null, "GET", qsb.BuildPathAndQuery());
+			return PerformHttpRequest<OrganizationList>(authToken, "GET", qsb.BuildPathAndQuery());
 		}
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Organization GetOrganizationById(string orgId)
 		{
-			return GetOrganization(string.Format("/GetOrganization?orgId={0}", orgId));
+			return GetOrganizationById(null, orgId);
 		}
 
+		public Organization GetOrganizationById(string authToken, string orgId)
+		{
+			return GetOrganization(authToken, string.Format("/GetOrganization?orgId={0}", orgId));
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Organization GetOrganizationByBoxId(string boxId)
 		{
-			return GetOrganization(string.Format("/GetOrganization?boxId={0}", boxId));
+			return GetOrganizationByBoxId(null, boxId);
 		}
 
+		public Organization GetOrganizationByBoxId(string authToken, string boxId)
+		{
+			return GetOrganization(authToken, string.Format("/GetOrganization?boxId={0}", boxId));
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Organization GetOrganizationByFnsParticipantId(string fnsParticipantId)
 		{
-			return GetOrganization(string.Format("/GetOrganization?fnsParticipantId={0}", fnsParticipantId));
+			return GetOrganizationByFnsParticipantId(null, fnsParticipantId);
 		}
 
+		public Organization GetOrganizationByFnsParticipantId(string authToken, string fnsParticipantId)
+		{
+			return GetOrganization(authToken, string.Format("/GetOrganization?fnsParticipantId={0}", fnsParticipantId));
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Organization GetOrganizationByInnKpp(string inn, string kpp)
+		{
+			return GetOrganizationByInnKpp(null, inn, kpp);
+		}
+
+		public Organization GetOrganizationByInnKpp(string authToken, string inn, string kpp)
 		{
 			var qsb = new PathAndQueryBuilder("/GetOrganization");
 			qsb.AddParameter("inn", inn);
 			if (!string.IsNullOrEmpty(kpp))
 				qsb.AddParameter("kpp", kpp);
 			var queryString = qsb.BuildPathAndQuery();
-			return GetOrganization(queryString);
+			return GetOrganization(authToken, queryString);
 		}
 
-		private Organization GetOrganization(string queryString)
+		private Organization GetOrganization(string authToken, string queryString)
 		{
-			return PerformHttpRequest<Organization>(null, "GET", queryString);
+			return PerformHttpRequest<Organization>(authToken, "GET", queryString);
 		}
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Box GetBox(string boxId)
 		{
+			return GetBox(null, boxId);
+		}
+
+		public Box GetBox(string authToken, string boxId)
+		{
 			var queryString = string.Format("/GetBox?boxId={0}", boxId);
-			return PerformHttpRequest<Box>(null, "GET", queryString);
+			return PerformHttpRequest<Box>(authToken, "GET", queryString);
 		}
 
 		public Department GetDepartment(string authToken, string orgId, string departmentId)
@@ -119,10 +156,16 @@ namespace Diadoc.Api
 			return PerformHttpRequest<OrganizationUsersList>(authToken, "GET", queryString);
 		}
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public List<Organization> GetOrganizationsByInnList(GetOrganizationsByInnListRequest innList)
 		{
+			return GetOrganizationsByInnList(null, innList);
+		}
+
+		public List<Organization> GetOrganizationsByInnList(string authToken, GetOrganizationsByInnListRequest innList)
+		{
 			const string queryString = "/GetOrganizationsByInnList";
-			var response = PerformHttpRequest<GetOrganizationsByInnListRequest, GetOrganizationsByInnListResponse>(null, queryString, innList);
+			var response = PerformHttpRequest<GetOrganizationsByInnListRequest, GetOrganizationsByInnListResponse>(authToken, queryString, innList);
 			return response.Organizations.Select(o => o.Organization).ToList();
 		}
 

--- a/src/DiadocHttpApi.ReferencesAsync.cs
+++ b/src/DiadocHttpApi.ReferencesAsync.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Diadoc.Api.Constants;
 using Diadoc.Api.Http;
 using Diadoc.Api.Proto;
 using Diadoc.Api.Proto.Certificates;
@@ -48,50 +49,86 @@ namespace Diadoc.Api
 			return PerformHttpRequestAsync<CertificateList>(authToken, "GET", queryBuilder.BuildPathAndQuery());
 		}
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<OrganizationList> GetOrganizationsByInnKppAsync(string inn, string kpp, bool includeRelations = false)
+		{
+			return GetOrganizationsByInnKppAsync(null, inn, kpp, includeRelations);
+		}
+
+		public Task<OrganizationList> GetOrganizationsByInnKppAsync(string authToken, string inn, string kpp, bool includeRelations = false)
 		{
 			var qsb = new PathAndQueryBuilder("/GetOrganizationsByInnKpp");
 			qsb.AddParameter("inn", inn);
 			if (!string.IsNullOrEmpty(kpp)) qsb.AddParameter("kpp", kpp);
 			if (includeRelations)
 				qsb.AddParameter("includeRelations", "true");
-			return PerformHttpRequestAsync<OrganizationList>(null, "GET", qsb.BuildPathAndQuery());
+			return PerformHttpRequestAsync<OrganizationList>(authToken, "GET", qsb.BuildPathAndQuery());
 		}
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<Organization> GetOrganizationByIdAsync(string orgId)
 		{
-			return GetOrganizationAsync($"/GetOrganization?orgId={orgId}");
+			return GetOrganizationByIdAsync(null, orgId);
 		}
 
+		public Task<Organization> GetOrganizationByIdAsync(string authToken, string orgId)
+		{
+			return GetOrganizationAsync(authToken, $"/GetOrganization?orgId={orgId}");
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<Organization> GetOrganizationByBoxIdAsync(string boxId)
 		{
-			return GetOrganizationAsync($"/GetOrganization?boxId={boxId}");
+			return GetOrganizationByBoxIdAsync(null, boxId);
 		}
 
+		public Task<Organization> GetOrganizationByBoxIdAsync(string authToken, string boxId)
+		{
+			return GetOrganizationAsync(authToken, $"/GetOrganization?boxId={boxId}");
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<Organization> GetOrganizationByFnsParticipantIdAsync(string fnsParticipantId)
 		{
-			return GetOrganizationAsync($"/GetOrganization?fnsParticipantId={fnsParticipantId}");
+			return GetOrganizationByFnsParticipantIdAsync(null, fnsParticipantId);
 		}
 
+		public Task<Organization> GetOrganizationByFnsParticipantIdAsync(string authToken, string fnsParticipantId)
+		{
+			return GetOrganizationAsync(authToken, $"/GetOrganization?fnsParticipantId={fnsParticipantId}");
+		}
+
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<Organization> GetOrganizationByInnKppAsync(string inn, string kpp)
+		{
+			return GetOrganizationByInnKppAsync(null, inn, kpp);
+		}
+
+		public Task<Organization> GetOrganizationByInnKppAsync(string authToken, string inn, string kpp)
 		{
 			var qsb = new PathAndQueryBuilder("/GetOrganization");
 			qsb.AddParameter("inn", inn);
 			if (!string.IsNullOrEmpty(kpp))
 				qsb.AddParameter("kpp", kpp);
 			var queryString = qsb.BuildPathAndQuery();
-			return GetOrganizationAsync(queryString);
+			return GetOrganizationAsync(authToken, queryString);
 		}
 
-		private Task<Organization> GetOrganizationAsync(string queryString)
+		private Task<Organization> GetOrganizationAsync(string authToken, string queryString)
 		{
-			return PerformHttpRequestAsync<Organization>(null, "GET", queryString);
+			return PerformHttpRequestAsync<Organization>(authToken, "GET", queryString);
 		}
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		public Task<Box> GetBoxAsync(string boxId)
 		{
+			return GetBoxAsync(null, boxId);
+		}
+
+		public Task<Box> GetBoxAsync(string authToken, string boxId)
+		{
 			var queryString = $"/GetBox?boxId={boxId}";
-			return PerformHttpRequestAsync<Box>(null, "GET", queryString);
+			return PerformHttpRequestAsync<Box>(authToken, "GET", queryString);
 		}
 
 		public Task<Department> GetDepartmentAsync(string authToken, string orgId, string departmentId)
@@ -120,10 +157,16 @@ namespace Diadoc.Api
 			return PerformHttpRequestAsync<OrganizationUsersList>(authToken, "GET", queryString);
 		}
 
-		public async Task<List<Organization>> GetOrganizationsByInnListAsync(GetOrganizationsByInnListRequest innList)
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
+		public Task<List<Organization>> GetOrganizationsByInnListAsync(GetOrganizationsByInnListRequest innList)
+		{
+			return GetOrganizationsByInnListAsync(null, innList);
+		}
+
+		public async Task<List<Organization>> GetOrganizationsByInnListAsync(string authToken, GetOrganizationsByInnListRequest innList)
 		{
 			const string queryString = "/GetOrganizationsByInnList";
-			var response = await PerformHttpRequestAsync<GetOrganizationsByInnListRequest, GetOrganizationsByInnListResponse>(null, queryString, innList).ConfigureAwait(false);
+			var response = await PerformHttpRequestAsync<GetOrganizationsByInnListRequest, GetOrganizationsByInnListResponse>(authToken, queryString, innList).ConfigureAwait(false);
 			return response.Organizations.Select(o => o.Organization).ToList();
 		}
 

--- a/src/IDiadocApi.cs
+++ b/src/IDiadocApi.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Security;
+using Diadoc.Api.Constants;
 using Diadoc.Api.Proto;
 using Diadoc.Api.Proto.Docflow;
 using Diadoc.Api.Proto.Documents;
@@ -61,13 +62,25 @@ namespace Diadoc.Api
 		string AuthenticateWithKeyConfirm(string thumbprint, string token, bool saveBinding = false);
 		OrganizationUserPermissions GetMyPermissions(string authToken, string orgId);
 		OrganizationList GetMyOrganizations(string authToken, bool autoRegister = true);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		OrganizationList GetOrganizationsByInnKpp(string inn, string kpp, bool includeRelations = false);
+		OrganizationList GetOrganizationsByInnKpp(string authToken, string inn, string kpp, bool includeRelations = false);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Organization GetOrganizationById(string orgId);
+		Organization GetOrganizationById(string authToken, string orgId);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Organization GetOrganizationByBoxId(string boxId);
+		Organization GetOrganizationByBoxId(string authToken, string boxId);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Organization GetOrganizationByFnsParticipantId(string fnsParticipantId);
+		Organization GetOrganizationByFnsParticipantId(string authToken, string fnsParticipantId);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Organization GetOrganizationByInnKpp(string inn, string kpp);
+		Organization GetOrganizationByInnKpp(string authToken, string inn, string kpp);
 		RoamingOperatorList GetRoamingOperators(string authToken, string boxId);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Box GetBox(string boxId);
+		Box GetBox(string authToken, string boxId);
 		Department GetDepartment(string authToken, string orgId, string departmentId);
 		void UpdateOrganizationProperties(string authToken, OrganizationPropertiesToUpdate orgProps);
 		OrganizationFeatures GetOrganizationFeatures(string authToken, string boxId);
@@ -187,21 +200,49 @@ namespace Diadoc.Api
 			int? limit = null);
 		string UploadFileToShelf(string authToken, byte[] data);
 		byte[] GetFileFromShelf(string authToken, string nameOnShelf);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		RussianAddress ParseRussianAddress(string address);
+		RussianAddress ParseRussianAddress(string authToken, string address);
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		InvoiceInfo ParseInvoiceXml(byte[] invoiceXmlContent);
+		InvoiceInfo ParseInvoiceXml(string authToken, byte[] invoiceXmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Torg12SellerTitleInfo ParseTorg12SellerTitleXml(byte[] xmlContent);
+		Torg12SellerTitleInfo ParseTorg12SellerTitleXml(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Torg12BuyerTitleInfo ParseTorg12BuyerTitleXml(byte[] xmlContent);
+		Torg12BuyerTitleInfo ParseTorg12BuyerTitleXml(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		TovTorgSellerTitleInfo ParseTovTorg551SellerTitleXml(byte[] xmlContent);
+		TovTorgSellerTitleInfo ParseTovTorg551SellerTitleXml(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		TovTorgBuyerTitleInfo ParseTovTorg551BuyerTitleXml(byte[] xmlContent);
+		TovTorgBuyerTitleInfo ParseTovTorg551BuyerTitleXml(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		AcceptanceCertificateSellerTitleInfo ParseAcceptanceCertificateSellerTitleXml(byte[] xmlContent);
+		AcceptanceCertificateSellerTitleInfo ParseAcceptanceCertificateSellerTitleXml(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		AcceptanceCertificateBuyerTitleInfo ParseAcceptanceCertificateBuyerTitleXml(byte[] xmlContent);
+		AcceptanceCertificateBuyerTitleInfo ParseAcceptanceCertificateBuyerTitleXml(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		AcceptanceCertificate552SellerTitleInfo ParseAcceptanceCertificate552SellerTitleXml(byte[] xmlContent);
+		AcceptanceCertificate552SellerTitleInfo ParseAcceptanceCertificate552SellerTitleXml(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		AcceptanceCertificate552BuyerTitleInfo ParseAcceptanceCertificate552BuyerTitleXml(byte[] xmlContent);
+		AcceptanceCertificate552BuyerTitleInfo ParseAcceptanceCertificate552BuyerTitleXml(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		UniversalTransferDocumentSellerTitleInfo ParseUniversalTransferDocumentSellerTitleXml(byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Utd);
+		UniversalTransferDocumentSellerTitleInfo ParseUniversalTransferDocumentSellerTitleXml(string authToken, byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Utd);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		UniversalTransferDocumentBuyerTitleInfo ParseUniversalTransferDocumentBuyerTitleXml(byte[] xmlContent);
+		UniversalTransferDocumentBuyerTitleInfo ParseUniversalTransferDocumentBuyerTitleXml(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		UniversalCorrectionDocumentSellerTitleInfo ParseUniversalCorrectionDocumentSellerTitleXml(byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Ucd);
+		UniversalCorrectionDocumentSellerTitleInfo ParseUniversalCorrectionDocumentSellerTitleXml(string authToken, byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Ucd);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		UniversalTransferDocumentBuyerTitleInfo ParseUniversalCorrectionDocumentBuyerTitleXml(byte[] xmlContent);
+		UniversalTransferDocumentBuyerTitleInfo ParseUniversalCorrectionDocumentBuyerTitleXml(string authToken, byte[] xmlContent);
 
 		byte[] ParseTitleXml(
 			string authToken,
@@ -215,10 +256,16 @@ namespace Diadoc.Api
 		[Obsolete("Use GetOrganizationUsersV2()")]
 		OrganizationUsersList GetOrganizationUsers(string authToken, string orgId);
 		OrganizationUsersList GetOrganizationUsersV2(string authToken, string boxId);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		List<Organization> GetOrganizationsByInnList(GetOrganizationsByInnListRequest innList);
+		List<Organization> GetOrganizationsByInnList(string authToken, GetOrganizationsByInnListRequest innList);
 		List<OrganizationWithCounteragentStatus> GetOrganizationsByInnList(string authToken, string myOrgId, GetOrganizationsByInnListRequest innList);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		RevocationRequestInfo ParseRevocationRequestXml(byte[] revocationRequestXmlContent);
+		RevocationRequestInfo ParseRevocationRequestXml(string authToken, byte[] revocationRequestXmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		SignatureRejectionInfo ParseSignatureRejectionXml(byte[] signatureRejectionXmlContent);
+		SignatureRejectionInfo ParseSignatureRejectionXml(string authToken, byte[] signatureRejectionXmlContent);
 		DocumentProtocolResult GenerateDocumentProtocol(string authToken, string boxId, string messageId, string documentId);
 		DocumentZipGenerationResult GenerateDocumentZip(string authToken, string boxId, string messageId, string documentId, bool fullDocflow);
 		DocumentList GetDocumentsByCustomId(string authToken, string boxId, string customDocumentId);
@@ -353,13 +400,25 @@ namespace Diadoc.Api
 		Task<UserV2> GetMyUserV2Async(string authToken);
 		Task<UserV2> UpdateMyUserAsync(string authToken, UserToUpdate userToUpdate);
 		Task<CertificateList> GetMyCertificatesAsync(string authToken, string boxId);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<OrganizationList> GetOrganizationsByInnKppAsync(string inn, string kpp, bool includeRelations = false);
+		Task<OrganizationList> GetOrganizationsByInnKppAsync(string authToken, string inn, string kpp, bool includeRelations = false);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<Organization> GetOrganizationByIdAsync(string orgId);
+		Task<Organization> GetOrganizationByIdAsync(string authToken, string orgId);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<Organization> GetOrganizationByBoxIdAsync(string boxId);
+		Task<Organization> GetOrganizationByBoxIdAsync(string authToken, string boxId);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<Organization> GetOrganizationByFnsParticipantIdAsync(string fnsParticipantId);
+		Task<Organization> GetOrganizationByFnsParticipantIdAsync(string authToken, string fnsParticipantId);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<Organization> GetOrganizationByInnKppAsync(string inn, string kpp);
+		Task<Organization> GetOrganizationByInnKppAsync(string authToken, string inn, string kpp);
 		Task<RoamingOperatorList> GetRoamingOperatorsAsync(string authToken, string boxId);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<Box> GetBoxAsync(string boxId);
+		Task<Box> GetBoxAsync(string authToken, string boxId);
 		Task<Department> GetDepartmentAsync(string authToken, string orgId, string departmentId);
 		Task UpdateOrganizationPropertiesAsync(string authToken, OrganizationPropertiesToUpdate orgProps);
 		Task<OrganizationFeatures> GetOrganizationFeaturesAsync(string authToken, string boxId);
@@ -515,21 +574,49 @@ namespace Diadoc.Api
 			int? limit = null);
 		Task<string> UploadFileToShelfAsync(string authToken, byte[] data);
 		Task<byte[]> GetFileFromShelfAsync(string authToken, string nameOnShelf);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<RussianAddress> ParseRussianAddressAsync(string address);
+		Task<RussianAddress> ParseRussianAddressAsync(string authToken, string address);
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<InvoiceInfo> ParseInvoiceXmlAsync(byte[] invoiceXmlContent);
+		Task<InvoiceInfo> ParseInvoiceXmlAsync(string authToken, byte[] invoiceXmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<Torg12SellerTitleInfo> ParseTorg12SellerTitleXmlAsync(byte[] xmlContent);
+		Task<Torg12SellerTitleInfo> ParseTorg12SellerTitleXmlAsync(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<Torg12BuyerTitleInfo> ParseTorg12BuyerTitleXmlAsync(byte[] xmlContent);
+		Task<Torg12BuyerTitleInfo> ParseTorg12BuyerTitleXmlAsync(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<TovTorgSellerTitleInfo> ParseTovTorg551SellerTitleXmlAsync(byte[] xmlContent);
+		Task<TovTorgSellerTitleInfo> ParseTovTorg551SellerTitleXmlAsync(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<TovTorgBuyerTitleInfo> ParseTovTorg551BuyerTitleXmlAsync(byte[] xmlContent);
+		Task<TovTorgBuyerTitleInfo> ParseTovTorg551BuyerTitleXmlAsync(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<AcceptanceCertificateSellerTitleInfo> ParseAcceptanceCertificateSellerTitleXmlAsync(byte[] xmlContent);
+		Task<AcceptanceCertificateSellerTitleInfo> ParseAcceptanceCertificateSellerTitleXmlAsync(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<AcceptanceCertificateBuyerTitleInfo> ParseAcceptanceCertificateBuyerTitleXmlAsync(byte[] xmlContent);
+		Task<AcceptanceCertificateBuyerTitleInfo> ParseAcceptanceCertificateBuyerTitleXmlAsync(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<AcceptanceCertificate552SellerTitleInfo> ParseAcceptanceCertificate552SellerTitleXmlAsync(byte[] xmlContent);
+		Task<AcceptanceCertificate552SellerTitleInfo> ParseAcceptanceCertificate552SellerTitleXmlAsync(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<AcceptanceCertificate552BuyerTitleInfo> ParseAcceptanceCertificate552BuyerTitleXmlAsync(byte[] xmlContent);
+		Task<AcceptanceCertificate552BuyerTitleInfo> ParseAcceptanceCertificate552BuyerTitleXmlAsync(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<UniversalTransferDocumentSellerTitleInfo> ParseUniversalTransferDocumentSellerTitleXmlAsync(byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Utd);
+		Task<UniversalTransferDocumentSellerTitleInfo> ParseUniversalTransferDocumentSellerTitleXmlAsync(string authToken, byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Utd);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<UniversalTransferDocumentBuyerTitleInfo> ParseUniversalTransferDocumentBuyerTitleXmlAsync(byte[] xmlContent);
+		Task<UniversalTransferDocumentBuyerTitleInfo> ParseUniversalTransferDocumentBuyerTitleXmlAsync(string authToken, byte[] xmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<UniversalCorrectionDocumentSellerTitleInfo> ParseUniversalCorrectionDocumentSellerTitleXmlAsync(byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Ucd);
+		Task<UniversalCorrectionDocumentSellerTitleInfo> ParseUniversalCorrectionDocumentSellerTitleXmlAsync(string authToken, byte[] xmlContent, string documentVersion = DefaultDocumentVersions.Ucd);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<UniversalTransferDocumentBuyerTitleInfo> ParseUniversalCorrectionDocumentBuyerTitleXmlAsync(byte[] xmlContent);
+		Task<UniversalTransferDocumentBuyerTitleInfo> ParseUniversalCorrectionDocumentBuyerTitleXmlAsync(string authToken, byte[] xmlContent);
 
 		Task<byte[]> ParseTitleXmlAsync(
 			string authToken,
@@ -544,10 +631,16 @@ namespace Diadoc.Api
 		Task<OrganizationUsersList> GetOrganizationUsersAsync(string authToken, string orgId);
 		Task<OrganizationUsersList> GetOrganizationUsersV2Async(string authToken, string boxId);
 
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<List<Organization>> GetOrganizationsByInnListAsync(GetOrganizationsByInnListRequest innList);
+		Task<List<Organization>> GetOrganizationsByInnListAsync(string authToken, GetOrganizationsByInnListRequest innList);
 		Task<List<OrganizationWithCounteragentStatus>> GetOrganizationsByInnListAsync(string authToken, string myOrgId, GetOrganizationsByInnListRequest innList);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<RevocationRequestInfo> ParseRevocationRequestXmlAsync(byte[] revocationRequestXmlContent);
+		Task<RevocationRequestInfo> ParseRevocationRequestXmlAsync(string authToken, byte[] revocationRequestXmlContent);
+		[Obsolete(ObsoleteReasons.UseAuthTokenOverload)]
 		Task<SignatureRejectionInfo> ParseSignatureRejectionXmlAsync(byte[] signatureRejectionXmlContent);
+		Task<SignatureRejectionInfo> ParseSignatureRejectionXmlAsync(string authToken, byte[] signatureRejectionXmlContent);
 		Task<DocumentProtocolResult> GenerateDocumentProtocolAsync(string authToken, string boxId, string messageId, string documentId);
 		Task<DocumentZipGenerationResult> GenerateDocumentZipAsync(string authToken, string boxId, string messageId, string documentId, bool fullDocflow);
 		Task<DocumentList> GetDocumentsByCustomIdAsync(string authToken, string boxId, string customDocumentId);

--- a/tests/ApiMethodsHelper.cs
+++ b/tests/ApiMethodsHelper.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Diadoc.Api.Tests
+{
+	public static class ApiMethodsHelper
+	{
+		private static readonly HashSet<string> ObjectMethods = new HashSet<string>(typeof(object).GetMethods().Select(x => x.Name));
+
+		public static IEnumerable<MethodInfo> GetAllApiMethodsForType(Type type, ICollection<string> exceptMethods)
+		{
+			return type.GetMethods()
+				.Where(x => !x.Name.StartsWith("get_") && !x.Name.StartsWith("set_"))
+				.Where(x => !exceptMethods.Contains(x.Name))
+				.Where(x => !ObjectMethods.Contains(x.Name));
+		}
+	}
+}

--- a/tests/AuthToken_Test.cs
+++ b/tests/AuthToken_Test.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Diadoc.Api.Tests
+{
+	public class AuthToken_Test
+	{
+		[Test]
+		[TestCase(typeof(IDiadocApi))]
+		[TestCase(typeof(DiadocHttpApi))]
+		[TestCase(typeof(IDocflowApi))]
+		[TestCase(typeof(DiadocHttpApi.DocflowHttpApi))]
+		[TestCase(typeof(IComDiadocApi))]
+		public void Every_api_method_has_overload_with_auth_token(Type clientType)
+		{
+			foreach (var methodInfo in ApiMethodsHelper.GetAllApiMethodsForType(clientType, ExceptMethods))
+			{
+				var parameters = methodInfo.GetParameters();
+				if (parameters.Any(x => (x.Name == "token" || x.Name == "authToken") && x.ParameterType == typeof(string)))
+				{
+					continue;
+				}
+
+				var parametersWithToken = new List<Type> {typeof(string)};
+				parametersWithToken.AddRange(parameters.Select(x => x.ParameterType));
+				var counterpartWithToken = clientType.GetMethod(methodInfo.Name, parametersWithToken.ToArray());
+				Assert.That(counterpartWithToken, Is.Not.Null, () => $"Method doesn't have overload with authToken: {clientType}.{methodInfo.Name}");
+			}
+		}
+
+		[Test]
+		[TestCase(typeof(IDiadocApi))]
+		[TestCase(typeof(DiadocHttpApi))]
+		[TestCase(typeof(IDocflowApi))]
+		[TestCase(typeof(DiadocHttpApi.DocflowHttpApi))]
+		[TestCase(typeof(IComDiadocApi))]
+		public void Every_api_method_without_auth_token_is_marked_obsolete(Type clientType)
+		{
+			foreach (var methodInfo in ApiMethodsHelper.GetAllApiMethodsForType(clientType, ExceptMethods))
+			{
+				var parameters = methodInfo.GetParameters();
+				if (parameters.Any(x => (x.Name == "token" || x.Name == "authToken") && x.ParameterType == typeof(string)))
+				{
+					continue;
+				}
+
+				var obsoleteAttribute = methodInfo.GetCustomAttributes(typeof(ObsoleteAttribute), true);
+				Assert.That(obsoleteAttribute, Is.Not.Null);
+			}
+		}
+		
+		private static readonly HashSet<string> ExceptMethods = new HashSet<string>
+		{
+			"SetProxyUri",
+			"EnableSystemProxyUsage",
+			"DisableSystemProxyUsage",
+			"SetProxyCredentials",
+			"SetSolutionInfo",
+			"UseOidc",
+			"Initialize",
+			"SetProxyCredentialsSecure",
+			"CreateNewId",
+			"NewGuid",
+			"NullDateTime",
+			"AuthenticateWithPassword",
+			"AuthenticateWithCertificate",
+			"AuthenticateWithSid",
+			"AuthenticateAsync",
+			"AuthenticateByKeyAsync",
+			"AuthenticateBySidAsync",
+			"AuthenticateWithKeyAsync",
+			"Authenticate",
+			"AuthenticateByKey",
+			"AuthenticateBySid",
+			"AuthenticateWithKey",
+			"Recognize",
+			"GetRecognized",
+			"RecognizeAsync",
+			"GetRecognizedAsync",
+			"GetExternalServiceAuthInfo",
+			"GetExternalServiceAuthInfoAsync"
+		};
+	}
+}

--- a/tests/TaskAsyncronousPattern_Test.cs
+++ b/tests/TaskAsyncronousPattern_Test.cs
@@ -101,12 +101,14 @@ namespace Diadoc.Api.Tests
 				typeof(DocflowApi),
 				typeof(DiadocHttpApi.DocflowHttpApi)
 			};
-			return apiTypes.SelectMany(GetAllApiMethodsForType);
+			return apiTypes.SelectMany(type => ApiMethodsHelper.GetAllApiMethodsForType(type, ExceptMethods));
 		}
 
 		private static IEnumerable<MethodInfo> GetAllDiadocHttpApiMethods()
 		{
-			return GetAllApiMethodsForType(typeof(DiadocHttpApi)).Where(x => !x.Name.StartsWith("WaitTaskResult"));
+			return ApiMethodsHelper
+				.GetAllApiMethodsForType(typeof(DiadocHttpApi), ExceptMethods)
+				.Where(x => !x.Name.StartsWith("WaitTaskResult"));
 		}
 
 		private static readonly string[] ExceptMethods =
@@ -118,15 +120,5 @@ namespace Diadoc.Api.Tests
 			"SetSolutionInfo",
 			"UseOidc"
 		};
-
-		private static readonly string[] ObjectMethods = typeof(object).GetMethods().Select(x => x.Name).ToArray();
-
-		private static IEnumerable<MethodInfo> GetAllApiMethodsForType(Type type)
-		{
-			return type.GetMethods()
-				.Where(x => !x.Name.StartsWith("get_") && !x.Name.StartsWith("set_"))
-				.Where(x => !ExceptMethods.Contains(x.Name))
-				.Where(x => !ObjectMethods.Contains(x.Name));
-		}
 	}
 }

--- a/tests/TaskAsyncronousPattern_Test.cs
+++ b/tests/TaskAsyncronousPattern_Test.cs
@@ -115,7 +115,8 @@ namespace Diadoc.Api.Tests
 			"EnableSystemProxyUsage",
 			"DisableSystemProxyUsage",
 			"SetProxyCredentials",
-			"SetSolutionInfo"
+			"SetSolutionInfo",
+			"UseOidc"
 		};
 
 		private static readonly string[] ObjectMethods = typeof(object).GetMethods().Select(x => x.Name).ToArray();


### PR DESCRIPTION
DDCORE-8610

* Add UseOidc method to turn on OIDC authentication. Technically that just changes value of the `Authorization` header from `DiadocToken` scheme to `Bearer` scheme.
* Add overload with `authToken` argument to methods that haven't had them. These methods don't require `DiadocToken` on server side. But it will be required to pass `authToken` with OIDC. Both overloads will work with DiadocToken without any problems. Checked methods in public client types: `IDiadocApi`, `DiadocHttpApi`, `IDocflowApi`, `DocflowHttpApi`, `IComDiadocApi`.
* Add a test that enforces "overload with `authToken` must exist" rule on public client types.
* Later, after public announcement about OIDC, overloads without `authToken` argument will be marked obsolete.  

<details><summary>List of methods that don't require DiadocToken on server</summary>

The list was builded automatically using reflection. It contains all actions in server app with `[SkipTokenValidation]` attribute.

➖ -- overload is not required, because the method isn't going to be used with OIDC
🚶 -- overload is not required because the method is gone (API responds with HTTP 410)
Ⓜ️ -- the methods missed from the client and overload wasn't added too
✅ -- the method either already had overload with `authToken` or such overload was added

* ➖ Authenticate
* Ⓜ️ Devices
* ✅ GenerateAcceptanceCertificateXmlForSeller
* ✅ GenerateInvoiceXml
* ✅ GenerateTorg12XmlForSeller
* ✅ GenerateUniversalTransferDocumentXmlForSeller
* ✅ GetBox
* Ⓜ️ GetBoxesByInnKpp
* Ⓜ️ GetBoxInfo
* 🚶 GetExternalServiceAuthInfo
* ✅ GetOrganization
* ✅ GetOrganizationsByInnKpp
* ✅ GetOrganizationsByInnList
* 🚶 GetRecognized
* ✅ ParseAcceptanceCertificateBuyerTitleXml
* ✅ ParseAcceptanceCertificateSellerTitleXml
* ✅ ParseInvoiceXml
* ✅ ParseRevocationRequestXml
* ✅ ParseRussianAddress
* ✅ ParseSignatureRejectionXml
* ✅ ParseTorg12BuyerTitleXml
* ✅ ParseTorg12SellerTitleXml
* ✅ ParseUniversalCorrectionDocumentBuyerTitleXml
* ✅ ParseUniversalCorrectionDocumentSellerTitleXml
* ✅ ParseUniversalTransferDocumentBuyerTitleXml
* ✅ ParseUniversalTransferDocumentSellerTitleXml
* 🚶 Recognize
* Ⓜ️ SendMessage
* Ⓜ️ PostDraft
* ➖ V2/Authenticate
* ➖ V2/AuthenticateConfirm
* Ⓜ️ V2/ParseRussianAddress
* ➖ V3/Authenticate
* Ⓜ️ VerifyThatUserHasAccessToAnyBox

</details>