### PR TITLE
ddcore-9813 PublicAPI: научиться жать трафик

### DIFF
--- a/src/DiadocHttpApi.cs
+++ b/src/DiadocHttpApi.cs
@@ -154,7 +154,6 @@ namespace Diadoc.Api
 		{
 			var request = new HttpRequest(method, queryString, body, accept: httpSerializer.ResponseContentType);
 			request.AddHeader("Authorization", GetAuthorizationHeaderValue(token));
-			request.AddHeader("Accept-Encoding", "gzip, deflate, br, zstd");
 			if (!string.IsNullOrEmpty(SolutionInfo))
 			{
 				request.AddHeader("X-Solution-Info", SolutionInfo);

--- a/src/Http/HttpClient.cs
+++ b/src/Http/HttpClient.cs
@@ -259,6 +259,7 @@ namespace Diadoc.Api.Http
 			webRequest.Method = request.Method;
 			webRequest.Timeout = request.TimeoutInSeconds * 1000;
 			webRequest.AllowAutoRedirect = true;
+			webRequest.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
 			if (ClientCertificate != null)
 			{
 				webRequest.ClientCertificates.Add(ClientCertificate);


### PR DESCRIPTION
В рамках задачи сжатия трафика в  сервисе PublicApi она была реализована. После того как сервис развернули на стенд stage, метрики исходящего трафика не изменились. Пришли к выводу, что клиенты не используют заголовок Accept-Encoding. Было принято добавить его в sdk диадока.