### PR TITLE
ddcore-10356: add new method GetResolutionRoutes, mark old methods as…

### DIFF
--- a/src/DiadocApi.Async.cs
+++ b/src/DiadocApi.Async.cs
@@ -1433,6 +1433,7 @@ namespace Diadoc.Api
 			return diadocHttpApi.PostExtendedSignerDetailsAsync(token, boxId, thumbprint, forBuyer, forCorrection, signerDetails);
 		}
 
+		[Obsolete("Use GetResolutionRoutesAsync")]
 		public Task<ResolutionRouteList> GetResolutionRoutesForOrganizationAsync(string authToken, string orgId)
 		{
 			if (string.IsNullOrEmpty(authToken))
@@ -1441,6 +1442,15 @@ namespace Diadoc.Api
 				throw new ArgumentNullException("orgId");
 			return diadocHttpApi.GetResolutionRoutesForOrganizationAsync(authToken, orgId);
 		}
+
+		public Task<ResolutionRouteList> GetResolutionRoutesAsync(string authToken, string boxId)
+		{
+			if (string.IsNullOrEmpty(authToken))
+				throw new ArgumentNullException(nameof(authToken));
+			if (string.IsNullOrEmpty(boxId))
+				throw new ArgumentNullException(nameof(boxId));
+			return diadocHttpApi.GetResolutionRoutesAsync(authToken, boxId);
+		}		
 
 		public Task<GetDocumentTypesResponseV2> GetDocumentTypesV2Async(string authToken, string boxId)
 		{

--- a/src/DiadocApi.cs
+++ b/src/DiadocApi.cs
@@ -1586,6 +1586,7 @@ namespace Diadoc.Api
 			return diadocHttpApi.PostExtendedSignerDetails(token, boxId, thumbprint, forBuyer, forCorrection, signerDetails);
 		}
 
+		[Obsolete("Use GetResolutionRoutes")]
 		public ResolutionRouteList GetResolutionRoutesForOrganization(string authToken, string orgId)
 		{
 			if (string.IsNullOrEmpty(authToken))
@@ -1594,6 +1595,15 @@ namespace Diadoc.Api
 				throw new ArgumentNullException("orgId");
 			return diadocHttpApi.GetResolutionRoutesForOrganization(authToken, orgId);
 		}
+
+		public ResolutionRouteList GetResolutionRoutes(string authToken, string boxId)
+		{
+			if (string.IsNullOrEmpty(authToken))
+				throw new ArgumentNullException(nameof(authToken));
+			if (string.IsNullOrEmpty(boxId))
+				throw new ArgumentNullException(nameof(boxId));
+			return diadocHttpApi.GetResolutionRoutes(authToken, boxId);
+		}		
 
 		public GetDocumentTypesResponseV2 GetDocumentTypesV2(string authToken, string boxId)
 		{

--- a/src/DiadocHttpApi.Documents.cs
+++ b/src/DiadocHttpApi.Documents.cs
@@ -133,10 +133,17 @@ namespace Diadoc.Api
 			return PerformHttpRequest<SignatureInfo>(authToken, "GET", qsb.BuildPathAndQuery());
 		}
 
-		[NotNull]
+		[Obsolete("Use GetResolutionRoutes")]
 		public ResolutionRouteList GetResolutionRoutesForOrganization([NotNull] string authToken, [NotNull] string orgId)
 		{
 			var queryString = string.Format("/GetResolutionRoutesForOrganization?orgId={0}", orgId);
+			return PerformHttpRequest<ResolutionRouteList>(authToken, "GET", queryString);
+		}
+
+		[NotNull]
+		public ResolutionRouteList GetResolutionRoutes([NotNull] string authToken, [NotNull] string boxId)
+		{
+			var queryString = $"/GetResolutionRoutes?boxId={boxId}";
 			return PerformHttpRequest<ResolutionRouteList>(authToken, "GET", queryString);
 		}
 

--- a/src/DiadocHttpApi.DocumentsAsync.cs
+++ b/src/DiadocHttpApi.DocumentsAsync.cs
@@ -131,13 +131,21 @@ namespace Diadoc.Api
 			return PerformHttpRequestAsync<SignatureInfo>(authToken, "GET", qsb.BuildPathAndQuery());
 		}
 
-		[ItemNotNull]
+		[Obsolete("Use GetResolutionRoutesAsync")]
 		public Task<ResolutionRouteList> GetResolutionRoutesForOrganizationAsync([NotNull] string authToken, [NotNull] string orgId)
 		{
 			var qsb = new PathAndQueryBuilder("/GetResolutionRoutesForOrganization");
 			qsb.AddParameter("orgId", orgId);
 			return PerformHttpRequestAsync<ResolutionRouteList>(authToken, "GET", qsb.BuildPathAndQuery());
 		}
+
+		[ItemNotNull]
+		public Task<ResolutionRouteList> GetResolutionRoutesAsync([NotNull] string authToken, [NotNull] string boxId)
+		{
+			var qsb = new PathAndQueryBuilder("/GetResolutionRoutes");
+			qsb.AddParameter("boxId", boxId);
+			return PerformHttpRequestAsync<ResolutionRouteList>(authToken, "GET", qsb.BuildPathAndQuery());
+		}		
 
 		public Task<GetDocumentTypesResponseV2> GetDocumentTypesV2Async(string authToken, string boxId)
 		{

--- a/src/IDiadocApi.cs
+++ b/src/IDiadocApi.cs
@@ -338,7 +338,9 @@ namespace Diadoc.Api
 		ExtendedSignerDetails GetExtendedSignerDetails(string token, string boxId, byte[] certificateBytes, bool forBuyer, bool forCorrection);
 		ExtendedSignerDetails PostExtendedSignerDetails(string token, string boxId, string thumbprint, bool forBuyer, bool forCorrection, ExtendedSignerDetailsToPost signerDetails);
 		ExtendedSignerDetails PostExtendedSignerDetails(string token, string boxId, byte[] certificateBytes, bool forBuyer, bool forCorrection, ExtendedSignerDetailsToPost signerDetails);
+		[Obsolete("Use GetResolutionRoutes()")]
 		ResolutionRouteList GetResolutionRoutesForOrganization(string authToken, string orgId);
+		ResolutionRouteList GetResolutionRoutes(string authToken, string boxId);
 		SignatureInfo GetSignatureInfo(string authToken, string boxId, string messageId, string entityId);
 
 		ExtendedSignerDetails GetExtendedSignerDetails(string token, string boxId, string thumbprint, DocumentTitleType documentTitleType);
@@ -755,7 +757,9 @@ namespace Diadoc.Api
 		Task<ExtendedSignerDetails> GetExtendedSignerDetailsAsync(string token, string boxId, byte[] certificateBytes, bool forBuyer, bool forCorrection);
 		Task<ExtendedSignerDetails> PostExtendedSignerDetailsAsync(string token, string boxId, string thumbprint, bool forBuyer, bool forCorrection, ExtendedSignerDetailsToPost signerDetails);
 		Task<ExtendedSignerDetails> PostExtendedSignerDetailsAsync(string token, string boxId, byte[] certificateBytes, bool forBuyer, bool forCorrection, ExtendedSignerDetailsToPost signerDetails);
+		[Obsolete("Use GetResolutionRoutesAsync()")]
 		Task<ResolutionRouteList> GetResolutionRoutesForOrganizationAsync(string authToken, string orgId);
+		Task<ResolutionRouteList> GetResolutionRoutesAsync(string authToken, string boxId);
 		Task<GetDocumentTypesResponseV2> GetDocumentTypesV2Async(string authToken, string boxId);
 		Task<DetectDocumentTypesResponse> DetectDocumentTypesAsync(string authToken, string boxId, string nameOnShelf);
 		Task<DetectDocumentTypesResponse> DetectDocumentTypesAsync(string authToken, string boxId, byte[] content);


### PR DESCRIPTION
- mark old methods GetResolutionRoutesForOrganization/Async as obsolete
- add new method GetResolutionRoutes that takes `boxId` as a parameter