### PR TITLE
Add lost contract in MessagePatch

### DIFF
--- a/proto/Events/DiadocMessage-GetApi.proto
+++ b/proto/Events/DiadocMessage-GetApi.proto
@@ -92,6 +92,7 @@ message MessagePatch {
 	optional bool MessageIsDelivered = 11 [default = false];
 	optional string DeliveredPatchId = 12;
 	required string PatchId = 13;
+	optional string NotDeliveredEventId = 14;
 
 	required Documents.MessageType MessageType = 15;
 }

--- a/src/Proto/Events/DiadocMessage-GetApi.proto.cs
+++ b/src/Proto/Events/DiadocMessage-GetApi.proto.cs
@@ -531,6 +531,15 @@ namespace Diadoc.Api.Proto.Events
       get { return _PatchId; }
       set { _PatchId = value; }
     }
+
+    private string _NotDeliveredEventId = "";
+    [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"NotDeliveredEventId", DataFormat = global::ProtoBuf.DataFormat.Default)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string NotDeliveredEventId
+    {
+      get { return _NotDeliveredEventId; }
+      set { _NotDeliveredEventId = value; }
+    }
     private Diadoc.Api.Proto.Documents.MessageType _MessageType;
     [global::ProtoBuf.ProtoMember(15, IsRequired = true, Name=@"MessageType", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public Diadoc.Api.Proto.Documents.MessageType MessageType


### PR DESCRIPTION
Add lost [contract NotDeliveredEventId](https://developer.kontur.ru/docs/diadoc-api/proto/MessagePatch.html) in MessagePatch/