### PR TITLE
Fix rules for release creation

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -40,7 +40,7 @@ jobs:
   publish:
     runs-on: ubuntu-22.04
     needs: build_and_test
-    if: startsWith(github.event.ref, 'refs/tags/version')
+    if: startsWith(github.ref, 'refs/tags/version') && github.event.base_ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Run release creation only for master branch