### PR TITLE
DDCORE-14466: Добавлен overload GeneratePrintFormFromAttachment со строковым documentType

### DIFF
--- a/src/ComDiadocApi.cs
+++ b/src/ComDiadocApi.cs
@@ -341,6 +341,7 @@ namespace Diadoc.Api
 		PrintFormResult GetGeneratedPrintForm(string authToken, string printFormId);
 
 		string GeneratePrintFormFromAttachment(string authToken, int documentType, byte[] content);
+		string GeneratePrintFormFromAttachment(string authToken, string documentType, byte[] content, string fromBoxId = null);
 
 		DateTime NullDateTime();
 
@@ -1820,6 +1821,11 @@ namespace Diadoc.Api
 		public string GeneratePrintFormFromAttachment(string authToken, int documentType, byte[] content)
 		{
 			return diadoc.GeneratePrintFormFromAttachment(authToken, (DocumentType) documentType, content);
+		}
+
+		public string GeneratePrintFormFromAttachment(string authToken, string documentType, byte[] content, string fromBoxId = null)
+		{
+			return diadoc.GeneratePrintFormFromAttachment(authToken, documentType, content, fromBoxId);
 		}
 
 		public DateTime NullDateTime()

--- a/src/ComDiadocApi.cs
+++ b/src/ComDiadocApi.cs
@@ -340,7 +340,9 @@ namespace Diadoc.Api
 
 		PrintFormResult GetGeneratedPrintForm(string authToken, string printFormId);
 
+		[Obsolete("Use GeneratePrintFormFromAttachment with string documentType parameter")]
 		string GeneratePrintFormFromAttachment(string authToken, int documentType, byte[] content);
+		
 		string GeneratePrintFormFromAttachment(string authToken, string documentType, byte[] content, string fromBoxId = null);
 
 		DateTime NullDateTime();
@@ -1818,6 +1820,7 @@ namespace Diadoc.Api
 			return diadoc.GetGeneratedPrintForm(authToken, printFormId);
 		}
 
+		[Obsolete("Use GeneratePrintFormFromAttachment with string documentType parameter")]
 		public string GeneratePrintFormFromAttachment(string authToken, int documentType, byte[] content)
 		{
 			return diadoc.GeneratePrintFormFromAttachment(authToken, (DocumentType) documentType, content);

--- a/src/DiadocApi.Async.cs
+++ b/src/DiadocApi.Async.cs
@@ -761,6 +761,7 @@ namespace Diadoc.Api
 			return diadocHttpApi.GeneratePrintFormAsync(authToken, boxId, messageId, documentId);
 		}
 
+		[Obsolete("Use GeneratePrintFormFromAttachmentAsync with string documentType parameter")]
 		public Task<string> GeneratePrintFormFromAttachmentAsync(string authToken, DocumentType documentType, byte[] content,
 			string fromBoxId = null)
 		{

--- a/src/DiadocApi.Async.cs
+++ b/src/DiadocApi.Async.cs
@@ -767,6 +767,12 @@ namespace Diadoc.Api
 			return diadocHttpApi.GeneratePrintFormFromAttachmentAsync(authToken, documentType, content, fromBoxId);
 		}
 
+		public Task<string> GeneratePrintFormFromAttachmentAsync(string authToken, string documentType, byte[] content,
+			string fromBoxId = null)
+		{
+			return diadocHttpApi.GeneratePrintFormFromAttachmentAsync(authToken, documentType, content, fromBoxId);
+		}
+
 		[Obsolete("Use GetGeneratedPrintFormAsync without `documentType` parameter")]
 		public Task<PrintFormResult> GetGeneratedPrintFormAsync(string authToken, DocumentType documentType, string printFormId)
 		{

--- a/src/DiadocApi.cs
+++ b/src/DiadocApi.cs
@@ -896,6 +896,14 @@ namespace Diadoc.Api
 			return diadocHttpApi.GeneratePrintFormFromAttachment(authToken, documentType, content, fromBoxId);
 		}
 
+		public string GeneratePrintFormFromAttachment(string authToken,
+			string documentType,
+			byte[] content,
+			string fromBoxId = null)
+		{
+			return diadocHttpApi.GeneratePrintFormFromAttachment(authToken, documentType, content, fromBoxId);
+		}
+
 		[Obsolete("Use GetGeneratedPrintForm without `documentType` parameter")]
 		public PrintFormResult GetGeneratedPrintForm(string authToken, DocumentType documentType, string printFormId)
 		{

--- a/src/DiadocApi.cs
+++ b/src/DiadocApi.cs
@@ -888,6 +888,7 @@ namespace Diadoc.Api
 			return diadocHttpApi.GeneratePrintForm(authToken, boxId, messageId, documentId);
 		}
 
+		[Obsolete("Use GeneratePrintFormFromAttachment with string documentType parameter")]
 		public string GeneratePrintFormFromAttachment(string authToken,
 			DocumentType documentType,
 			byte[] content,

--- a/src/DiadocHttpApi.Print.cs
+++ b/src/DiadocHttpApi.Print.cs
@@ -12,6 +12,12 @@ namespace Diadoc.Api
 		[NotNull]
 		public string GeneratePrintFormFromAttachment(string authToken, DocumentType documentType, byte[] content, string fromBoxId = null)
 		{
+			return GeneratePrintFormFromAttachment(authToken, documentType.ToString(), content, fromBoxId);
+		}
+
+		[NotNull]
+		public string GeneratePrintFormFromAttachment(string authToken, string documentType, byte[] content, string fromBoxId = null)
+		{
 			var queryString = new StringBuilder();
 			queryString.AppendFormat("/GeneratePrintFormFromAttachment?documentType={0}", documentType);
 			if (!string.IsNullOrEmpty(fromBoxId))

--- a/src/DiadocHttpApi.Print.cs
+++ b/src/DiadocHttpApi.Print.cs
@@ -9,6 +9,7 @@ namespace Diadoc.Api
 {
 	public partial class DiadocHttpApi
 	{
+		[Obsolete("Use GeneratePrintFormFromAttachment with string documentType parameter")]
 		[NotNull]
 		public string GeneratePrintFormFromAttachment(string authToken, DocumentType documentType, byte[] content, string fromBoxId = null)
 		{

--- a/src/DiadocHttpApi.PrintAsync.cs
+++ b/src/DiadocHttpApi.PrintAsync.cs
@@ -10,6 +10,7 @@ namespace Diadoc.Api
 {
 	public partial class DiadocHttpApi
 	{
+		[Obsolete("Use GeneratePrintFormFromAttachmentAsync with string documentType parameter")]
 		[ItemNotNull]
 		public async Task<string> GeneratePrintFormFromAttachmentAsync(string authToken, DocumentType documentType, byte[] content, string fromBoxId = null)
 		{

--- a/src/DiadocHttpApi.PrintAsync.cs
+++ b/src/DiadocHttpApi.PrintAsync.cs
@@ -13,8 +13,14 @@ namespace Diadoc.Api
 		[ItemNotNull]
 		public async Task<string> GeneratePrintFormFromAttachmentAsync(string authToken, DocumentType documentType, byte[] content, string fromBoxId = null)
 		{
+			return await GeneratePrintFormFromAttachmentAsync(authToken, documentType.ToString(), content, fromBoxId).ConfigureAwait(false);
+		}
+
+		[ItemNotNull]
+		public async Task<string> GeneratePrintFormFromAttachmentAsync(string authToken, string documentType, byte[] content, string fromBoxId = null)
+		{
 			var qsb = new PathAndQueryBuilder("/GeneratePrintFormFromAttachment")
-				.With("documentType", documentType.ToString());
+				.With("documentType", documentType);
 			if (!string.IsNullOrEmpty(fromBoxId))
 				qsb.AddParameter("fromBoxId", fromBoxId);
 			var responseBytes = await PerformHttpRequestAsync(authToken, "POST", qsb.BuildPathAndQuery(), content).ConfigureAwait(false);

--- a/src/IDiadocApi.cs
+++ b/src/IDiadocApi.cs
@@ -244,6 +244,7 @@ namespace Diadoc.Api
 		Message SendDraft(string authToken, DraftToSend draftToSend, string operationId = null);
 		PrintFormResult GeneratePrintForm(string authToken, string boxId, string messageId, string documentId);
 		string GeneratePrintFormFromAttachment(string authToken, DocumentType documentType, byte[] content, string fromBoxId = null);
+		string GeneratePrintFormFromAttachment(string authToken, string documentType, byte[] content, string fromBoxId = null);
 		[Obsolete("Use GetGeneratedPrintForm without `documentType` parameter")]
 		PrintFormResult GetGeneratedPrintForm(string authToken, DocumentType documentType, string printFormId);
 		PrintFormResult GetGeneratedPrintForm(string authToken, string printFormId);
@@ -751,6 +752,7 @@ namespace Diadoc.Api
 		Task<Message> SendDraftAsync(string authToken, DraftToSend draftToSend, string operationId = null);
 		Task<PrintFormResult> GeneratePrintFormAsync(string authToken, string boxId, string messageId, string documentId);
 		Task<string> GeneratePrintFormFromAttachmentAsync(string authToken, DocumentType documentType, byte[] content, string fromBoxId = null);
+я		Task<string> GeneratePrintFormFromAttachmentAsync(string authToken, string documentType, byte[] content, string fromBoxId = null);
 		[Obsolete("Use GetGeneratedPrintFormAsync without `documentType` parameter")]
 		Task<PrintFormResult> GetGeneratedPrintFormAsync(string authToken, DocumentType documentType, string printFormId);
 		Task<PrintFormResult> GetGeneratedPrintFormAsync(string authToken, string printFormId);

--- a/src/IDiadocApi.cs
+++ b/src/IDiadocApi.cs
@@ -752,7 +752,7 @@ namespace Diadoc.Api
 		Task<Message> SendDraftAsync(string authToken, DraftToSend draftToSend, string operationId = null);
 		Task<PrintFormResult> GeneratePrintFormAsync(string authToken, string boxId, string messageId, string documentId);
 		Task<string> GeneratePrintFormFromAttachmentAsync(string authToken, DocumentType documentType, byte[] content, string fromBoxId = null);
-я		Task<string> GeneratePrintFormFromAttachmentAsync(string authToken, string documentType, byte[] content, string fromBoxId = null);
+		Task<string> GeneratePrintFormFromAttachmentAsync(string authToken, string documentType, byte[] content, string fromBoxId = null);
 		[Obsolete("Use GetGeneratedPrintFormAsync without `documentType` parameter")]
 		Task<PrintFormResult> GetGeneratedPrintFormAsync(string authToken, DocumentType documentType, string printFormId);
 		Task<PrintFormResult> GetGeneratedPrintFormAsync(string authToken, string printFormId);

--- a/src/IDiadocApi.cs
+++ b/src/IDiadocApi.cs
@@ -243,6 +243,7 @@ namespace Diadoc.Api
 		void RecycleDraft(string authToken, string boxId, string draftId);
 		Message SendDraft(string authToken, DraftToSend draftToSend, string operationId = null);
 		PrintFormResult GeneratePrintForm(string authToken, string boxId, string messageId, string documentId);
+		[Obsolete("Use GeneratePrintFormFromAttachment with string documentType parameter")]
 		string GeneratePrintFormFromAttachment(string authToken, DocumentType documentType, byte[] content, string fromBoxId = null);
 		string GeneratePrintFormFromAttachment(string authToken, string documentType, byte[] content, string fromBoxId = null);
 		[Obsolete("Use GetGeneratedPrintForm without `documentType` parameter")]
@@ -751,6 +752,7 @@ namespace Diadoc.Api
 		Task RecycleDraftAsync(string authToken, string boxId, string draftId);
 		Task<Message> SendDraftAsync(string authToken, DraftToSend draftToSend, string operationId = null);
 		Task<PrintFormResult> GeneratePrintFormAsync(string authToken, string boxId, string messageId, string documentId);
+		[Obsolete("Use GeneratePrintFormFromAttachmentAsync with string documentType parameter")]
 		Task<string> GeneratePrintFormFromAttachmentAsync(string authToken, DocumentType documentType, byte[] content, string fromBoxId = null);
 		Task<string> GeneratePrintFormFromAttachmentAsync(string authToken, string documentType, byte[] content, string fromBoxId = null);
 		[Obsolete("Use GetGeneratedPrintFormAsync without `documentType` parameter")]


### PR DESCRIPTION
Добавлен новый overload GeneratePrintFormFromAttachment, принимающий documentType как string.

Метод добавлен в IDiadocApi, DiadocApi, DiadocHttpApi, async API и COM-обертку. Существующие варианты с DocumentType/int сохранены для обратной совместимости и при необходимости делегируют вызов в строковую реализацию.