### PR TITLE
DDCORE-14738 Updated contracts for Universal Message 2007

### DIFF
--- a/proto/Docflow/DocflowV4.proto
+++ b/proto/Docflow/DocflowV4.proto
@@ -41,6 +41,7 @@ message ParticipantResponseDocflowV4
     required Documents.RecipientResponseStatus ResponseStatus = 7;
     optional ConfirmationDocflowV4 Confirmation = 8;
     optional OutOfWorkflowUniversalMessageDocflow OutOfWorkflowUniversalMessageDocflow = 9;
+    optional AmendmentRequestDocflowV4 AmendmentRequest = 10;
 }
 
 message SignatureRejectionDocflowV4

--- a/proto/Documents/Document.proto
+++ b/proto/Documents/Document.proto
@@ -103,6 +103,7 @@ message Document {
 	optional TtGisFixationCancellationStatus TtGisFixationCancellationStatus = 81 [default = TtGisFixationCancellationStatusNone];
 	optional bool HasUnreadOutOfWorkflowUniversalMessages = 82 [default = true];
 	repeated DocumentParticipantInfo Participants = 83;
+	optional AmendmentRequestMetadata RecipientResponseAmendmentRequestMetadata = 84;
 }
 
 message LastOuterDocflow {

--- a/src/Com/DocflowsV4.cs
+++ b/src/Com/DocflowsV4.cs
@@ -218,6 +218,7 @@ namespace Diadoc.Api.Proto.Docflow
 		Com.RecipientResponseStatus ResponseStatusValue { get; }
 		ConfirmationDocflowV4 Confirmation { get; }
 		OutOfWorkflowUniversalMessageDocflow OutOfWorkflowUniversalMessageDocflow { get; }
+		AmendmentRequestDocflowV4 AmendmentRequest { get; }
 	}
 
 	[ComVisible(true)]

--- a/src/Com/InvoiceAmendmentFlags.cs
+++ b/src/Com/InvoiceAmendmentFlags.cs
@@ -15,6 +15,7 @@ namespace Diadoc.Api.Com
 		AmendmentRequested = 1,
 		Revised = 2,
 		Corrected = 4,
+		PoaAmendmentRequested = 8
 	}
 
 	public static class InvoiceAmendmentFlagsExtensions
@@ -32,6 +33,11 @@ namespace Diadoc.Api.Com
 		public static bool IsAmendmentRequested(this InvoiceAmendmentFlags status)
 		{
 			return (status & InvoiceAmendmentFlags.AmendmentRequested) == InvoiceAmendmentFlags.AmendmentRequested;
+		}
+		
+		public static bool IsPoaAmendmentRequested(this InvoiceAmendmentFlags status)
+		{
+			return (status & InvoiceAmendmentFlags.PoaAmendmentRequested) == InvoiceAmendmentFlags.PoaAmendmentRequested;
 		}
 	}
 }

--- a/src/Proto/Docflow/DocflowV4.proto.cs
+++ b/src/Proto/Docflow/DocflowV4.proto.cs
@@ -195,6 +195,15 @@ namespace Diadoc.Api.Proto.Docflow
       get { return _OutOfWorkflowUniversalMessageDocflow; }
       set { _OutOfWorkflowUniversalMessageDocflow = value; }
     }
+
+    private Diadoc.Api.Proto.Docflow.AmendmentRequestDocflowV4 _AmendmentRequest = null;
+    [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"AmendmentRequest", DataFormat = global::ProtoBuf.DataFormat.Default)]
+    [global::System.ComponentModel.DefaultValue(null)]
+    public Diadoc.Api.Proto.Docflow.AmendmentRequestDocflowV4 AmendmentRequest
+    {
+      get { return _AmendmentRequest; }
+      set { _AmendmentRequest = value; }
+    }
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/src/Proto/Documents/Document.cs
+++ b/src/Proto/Documents/Document.cs
@@ -56,6 +56,7 @@ namespace Diadoc.Api.Proto.Documents
 		RecipientReceiptMetadata RecipientReceiptMetadata { get; }
 		ConfirmationMetadata ConfirmationMetadata { get; }
 		AmendmentRequestMetadata AmendmentRequestMetadata { get; }
+		AmendmentRequestMetadata RecipientResponseAmendmentRequestMetadata { get; }
 		ReadonlyList MetadataList { get; }
 		bool IsDeleted { get; }
 		bool IsTest { get; }

--- a/src/Proto/Documents/Document.proto.cs
+++ b/src/Proto/Documents/Document.proto.cs
@@ -719,6 +719,15 @@ namespace Diadoc.Api.Proto.Documents
       get { return _Participants; }
     }
   
+
+    private Diadoc.Api.Proto.Documents.AmendmentRequestMetadata _RecipientResponseAmendmentRequestMetadata = null;
+    [global::ProtoBuf.ProtoMember(84, IsRequired = false, Name=@"RecipientResponseAmendmentRequestMetadata", DataFormat = global::ProtoBuf.DataFormat.Default)]
+    [global::System.ComponentModel.DefaultValue(null)]
+    public Diadoc.Api.Proto.Documents.AmendmentRequestMetadata RecipientResponseAmendmentRequestMetadata
+    {
+      get { return _RecipientResponseAmendmentRequestMetadata; }
+      set { _RecipientResponseAmendmentRequestMetadata = value; }
+    }
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }


### PR DESCRIPTION
DDCORE-14738: Добавлена поддержка УС 2007 на титул получателя в структурах Document и ParticipantResponseDocflowV4.